### PR TITLE
Add version info

### DIFF
--- a/pdsfile/__init__.py
+++ b/pdsfile/__init__.py
@@ -2,6 +2,11 @@
 # pdsfile/__init__.py
 ##########################################################################################
 
+try:
+    from ._version import __version__
+except ImportError as err:
+    __version__ = 'Version unspecified'
+
 from pdsfile import *
 from .pds3file import *
 from .pds4file import *


### PR DESCRIPTION
Add Python-build version info to the top-level module.

Examples:

```
$ python3.12 -m venv venv
$ source venv/bin/activate
$ pip install -r requirements.txt 
[...]
$ python
Python 3.12.0 (main, Oct  2 2023, 15:04:50) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pdsfile
>>> help(pdsfile)
...
VERSION
    Version unspecified
...

$ pip install -e .
Obtaining file:///seti/all_repos/rms-pdsfile
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... done
  Installing backend dependencies ... done
  Preparing editable metadata (pyproject.toml) ... done
[...]
Building wheels for collected packages: rms-pdsfile
  Building editable for rms-pdsfile (pyproject.toml) ... done
  Created wheel for rms-pdsfile: filename=rms_pdsfile-0.0.2.dev7-0.editable-py3-none-any.whl size=7669 sha256=9f70c7044b52f872f3528c116b27fe6b54df72b5370b0fb78052fddf78d1e168
  Stored in directory: /tmp/pip-ephem-wheel-cache-odpycim3/wheels/69/31/22/04d8930d4634c4b9987506704c4d84bcc5f2f0d6648f3ab667
Successfully built rms-pdsfile
Installing collected packages: rms-pdsfile
Successfully installed rms-pdsfile-0.0.2.dev7

$ python
Python 3.12.0 (main, Oct  2 2023, 15:04:50) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pdsfile
>>> help(pdsfile)
...
VERSION
    0.0.2.dev7
...
```
