### PR TITLE
PDS3 maintenance update; new attributes in Pds3File

### DIFF
--- a/holdings_maintenance/pds3/crlf.py
+++ b/holdings_maintenance/pds3/crlf.py
@@ -1,0 +1,121 @@
+##########################################################################################
+# crlf.py
+#
+# Program to validate and/or repair the CRLF line terminators in a file.
+#
+# Use:
+#   python crlf.py --repair file(s)     # Repair any files that have invalid terminators
+#   python crlf.py file(s)              # Identify any files with invalid terminators
+#
+# Files that are invalid are listed. Add the "--verbose" option to list all files checked,
+# even if they are OK.
+##########################################################################################
+
+import sys
+
+# Create a dictionary identifying non-ASCII characters with an "x"
+NON_ASCIIS = {}
+for c in range(32):
+    NON_ASCIIS[c] = 'x'
+for c in range(32, 128):
+    NON_ASCIIS[c] = None
+for c in range(128, 256):
+    NON_ASCIIS[c] = 'x'
+NON_ASCIIS[ord('\r')] = None
+NON_ASCIIS[ord('\n')] = None
+NON_ASCIIS[ord('\t')] = None
+
+
+def test_crlf(filepath, task='test', threshold=0.01):
+    """Test the presence of CRLF line terminators in the given file and optionally rewrite
+    it.
+
+    Parameters:
+        filepath (str or pathlib.Path): path to the file.
+        task (str): "test" to test the file; "repair" to rewrite it if necessary.
+        threshold (float): Fraction of non-ASCII characters indicating that this is a
+            binary file. If the the fraction of non-ASCII characters exceeds this value,
+            the file is not modified and "binary" is returned
+
+    Returns:
+        str: "BINARY" if the file is binary; "REPAIRED" if the file was rewritten;
+        "INVALID" if the file has invalid line terminators; "OK" otherwise.
+    """
+
+    if task not in {'test', 'repair'}:
+        raise ValueError('invalid task')
+
+    if not 0. <= threshold <= 1.:
+        raise ValueError('invalid threshold')
+
+    # Read the file as a byte string
+    with open(filepath, 'rb') as f:
+        content = f.read()
+
+    # Count the non-ASCII characters
+    content = content.decode('latin8')
+    non_asciis = len(content.translate(NON_ASCIIS))
+
+    # If the non-ASCII fraction is above the threshold, it's a binary file
+    if non_asciis/len(content) > threshold:
+        return 'BINARY'
+
+    # Split the file content into records
+    recs = content.split('\n')
+
+    # For each record not ending in CR, append the CR
+    repaired = False
+    for k, rec in enumerate(recs[:-1]):
+        if len(rec) == 0 or rec[-1] != '\r':
+            recs[k] = rec + '\r'
+            repaired = True
+
+    # Append CRLF at the end if it's missing
+    if recs[-1]:
+        recs[-1] += '\r\n'
+        repaired = True
+
+    # If the content has changed, rewrite the file
+    if repaired:
+        if task == 'repair':
+            content = '\n'.join(recs).encode('latin8')
+            with open(filepath, 'wb') as f:
+                f.write(content)
+            return 'REPAIRED'
+        return 'INVALID'
+
+    return 'OK'
+
+
+if __name__ == '__main__':
+
+    task = 'test'
+    if '--repair' in sys.argv:
+        sys.argv.remove('--repair')
+        task = 'repair'
+
+    verbose = False
+    if '--verbose' in sys.argv:
+        sys.argv.remove('--verbose')
+        verbose = True
+
+    repairs = 0
+    invalid = 0
+    for path in sys.argv[1:]:
+        status = test_crlf(path, task=task)
+        if verbose or status in {'REPAIRED', 'INVALID'}:
+            print(path, status)
+        if status == 'REPAIRED':
+            repairs += 1
+        if status == 'INVALID':
+            invalid += 1
+
+    nfiles = len(sys.argv[1:])
+    if nfiles > 1:
+        if repairs:
+            if repairs == 1:
+                print(f'{repairs}/{nfiles} files repaired')
+        elif invalid:
+                print(f'{invalid}/{nfiles} files invalid')
+        else:
+            print(str(nfiles), 'files tested')

--- a/holdings_maintenance/pds3/pdsdependency.py
+++ b/holdings_maintenance/pds3/pdsdependency.py
@@ -76,11 +76,15 @@ TESTS = translator.TranslatorByRegex([
     ('.*/JNCJNC_0xxx/.*',           0, ['metadata', 'cumindex999']),
     ('.*/HST.x_xxxx/.*',            0, ['hst', 'metadata', 'cumindex9_9999']),
     ('.*/NH..(LO|MV)_xxxx/.*',      0, ['metadata', 'supplemental', 'cumindexNH']),
-    ('.*/NH(JU|LA).._..../.*',      0, ['nhbrowse_vx', 'jupiter', 'rings', 'moons',
-                                        'inventory']),
-    ('.*/NH(PC|PE).._..../.*',      0, ['nhbrowse', 'pluto', 'rings', 'moons',
-                                        'inventory']),
-    ('.*/NH(KC|KE|K2).._..../.*',   0, ['nhbrowse']),
+    ('.*/NH(JU|LA)LO_[12]00.*',     0, ['jupiter', 'rings', 'moons', 'inventory']),
+    ('.*/NHP.LO_[12]00.*',          0, ['pluto', 'rings', 'moons', 'inventory']),
+    ('.*/NH[LPK].LO_[12]00.*',      0, ['nhbrowse']),
+    ('.*(?<!_v[12])/NHJULO_100.*',  0, ['nhbrowse']),       # not NHJULO_1001 _v1-2
+    ('.*(?<!_v[123])/NHJULO_200.*', 0, ['nhbrowse']),       # not NHJULO_2001 _v1-3
+    ('.*/NH[PK].MV_[12]00.*',       0, ['nhbrowse']),
+    ('.*(?<!_v1)/NHLAMV_[12]00.*',  0, ['nhbrowse_vx']),    # not LA _v1
+    ('.*/NHJUMV_100.*',             0, ['nhbrowse_vx']),
+    ('.*(?<!_v1)/NHJUMV_200.*',     0, ['nhbrowse_vx']),    # not NHJUMV_2001 _v1
     ('.*/RPX_xxxx/.*',              0, ['metadata']),
     ('.*/RPX_xxxx/RPX_000.*',       0, ['obsindex', 'cumindex99']),
     ('.*/VGISS_[5678]xxx/.*',       0, ['vgiss', 'metadata', 'raw_image',
@@ -213,12 +217,12 @@ class PdsDependency(object):
         confirmed = set()
         try:
             pattern = pdsdir.root_ + self.glob_pattern
-            pattern = pattern.replace('$', pdsdir.bundleset_[:-1], 1)
+            pattern = pattern.replace('$', pdsdir.volset_[:-1], 1)
             if '$' in pattern:
                 if self.func is None:
-                    volname = pdsdir.bundlename
+                    volname = pdsdir.volname
                 else:
-                    volname = self.func(pdsdir.bundlename, *self.args)
+                    volname = self.func(pdsdir.volname, *self.args)
                 pattern = pattern.replace('$', volname, 1)
 
             abspaths = glob.glob(pattern)
@@ -245,7 +249,6 @@ class PdsDependency(object):
 
                             (requirement, count) = self.regex.subn(sub, path)
                             absreq = (pdsdir.root_ + requirement)
-
                             if count == 0:
                                 logger.error('Invalid test', absreq)
                                 continue
@@ -886,28 +889,28 @@ _ = PdsDependency(
     r'<PREVIEW> [d]volumes/\1/\3.LBL -> [d]previews/\1/\3_*.jpg',
     suite='hst', newer=False)
 
-# For NHxxLO_xxxx and NHxxMV_xxxx browse, stripping version number
+# For NHxxLO_xxxx and NHxxMV_xxxx browse, stripping version number if present
 _ = PdsDependency(
     'Previews of every NH image file',
     'volumes/$/$/data/*/*.fit',
-    r'volumes/(NHxx.._....)(|_v[\.\d]+)/(NH.*?)(|_[0-9]+).fit',
+    r'volumes/(NHxx.._....)(|_v[\.\d]+)/(NH\w+/data/\w+/\w{24})(|_[0-9]+)\.fit',
     [r'previews/\1/\3_thumb.jpg',
      r'previews/\1/\3_small.jpg',
      r'previews/\1/\3_med.jpg',
      r'previews/\1/\3_full.jpg'],
-    r'<PREVIEW> [d]volumes/\1/\3\4.fit -> [d]previews/\1/\3_*.jpg',
+    r'<PREVIEW> [d]volumes/\1\2/\3\4.fit -> [d]previews/\1/\3_*.jpg',
     suite='nhbrowse', newer=False)
 
-# For NHxxLO_xxxx and NHxxMV_xxxx browse, without stripping version number
+# For NHxxLO_xxxx and NHxxMV_xxxx browse, retaining version number
 _ = PdsDependency(
     'Previews of every NH image file',
     'volumes/$/$/data/*/*.fit',
-    r'volumes/(NHxx.._....)(|_v[\.\d]+)/(NH.*?).fit',
+    r'volumes/(NHxx.._....)(|_v[\.\d]+)/(NH.*?)\.fit',
     [r'previews/\1/\3_thumb.jpg',
      r'previews/\1/\3_small.jpg',
      r'previews/\1/\3_med.jpg',
      r'previews/\1/\3_full.jpg'],
-    r'<PREVIEW> [d]volumes/\1/\3.fit -> [d]previews/\1/\3_*.jpg',
+    r'<PREVIEW> [d]volumes/\1\2/\3.fit -> [d]previews/\1/\3_*.jpg',
     suite='nhbrowse_vx', newer=False)
 
 # For VGISS_[5678]xxx
@@ -1060,6 +1063,13 @@ def main():
 
         else:
             paths.append(os.path.abspath(path))
+
+    # Check for valid volume IDs
+    for path in paths:
+        basename = os.path.basename(path)
+        if not pdsfile.Pds3File.VOLNAME_REGEX_I.match(basename):
+            print('Invalid volume ID: ' + path)
+            sys.exit(1)
 
     # Loop through paths...
     logger.open(' '.join(sys.argv))

--- a/pdsfile/pds3file/__init__.py
+++ b/pdsfile/pds3file/__init__.py
@@ -3,6 +3,8 @@
 # pds3file subpackage & Pds3File subclass with PdsFile as the parent class
 ##########################################################################################
 
+import re
+
 import pdslogger
 
 from pdsfile import pdscache
@@ -14,6 +16,41 @@ class Pds3File(PdsFile):
 
     PDS_HOLDINGS = 'holdings'
     BUNDLE_DIR_NAME = 'volumes'
+
+    # REGEX
+    BUNDLESET_REGEX        = re.compile(r'^([A-Z][A-Z0-9x]{1,5}_[0-9x]{3}x)$')
+    BUNDLESET_REGEX_I      = re.compile(BUNDLESET_REGEX.pattern, re.I)
+    BUNDLESET_PLUS_REGEX   = re.compile(BUNDLESET_REGEX.pattern[:-1] +
+                                        r'(_v[0-9]+\.[0-9]+\.[0-9]+|'+
+                                        r'_v[0-9]+\.[0-9]+|_v[0-9]+|'+
+                                        r'_in_prep|_prelim|_peer_review|'+
+                                        r'_lien_resolution|)' +
+                                        r'((|_calibrated|_diagrams|_metadata|_previews)' +
+                                        r'(|_md5\.txt|\.tar\.gz))$')
+    BUNDLESET_PLUS_REGEX_I = re.compile(BUNDLESET_PLUS_REGEX.pattern, re.I)
+
+    BUNDLENAME_REGEX       = re.compile(r'^([A-Z][A-Z0-9]{1,5}_(?:[0-9]{4}))$')
+    BUNDLENAME_REGEX_I     = re.compile(BUNDLENAME_REGEX.pattern, re.I)
+    BUNDLENAME_PLUS_REGEX  = re.compile(BUNDLENAME_REGEX.pattern[:-1] +
+                                        r'(|_[a-z]+)(|_md5\.txt|\.tar\.gz)$')
+    BUNDLENAME_PLUS_REGEX_I = re.compile(BUNDLENAME_PLUS_REGEX.pattern, re.I)
+    BUNDLENAME_VERSION     = re.compile(BUNDLENAME_REGEX.pattern[:-1] +
+                                        r'(_v[0-9]+\.[0-9]+\.[0-9]+|'+
+                                        r'_v[0-9]+\.[0-9]+|_v[0-9]+|'+
+                                        r'_in_prep|_prelim|_peer_review|'+
+                                        r'_lien_resolution)$')
+    BUNDLENAME_VERSION_I   = re.compile(BUNDLENAME_VERSION.pattern, re.I)
+
+    VOLSET_REGEX         = BUNDLESET_REGEX
+    VOLSET_REGEX_I       = BUNDLESET_REGEX_I
+    VOLSET_PLUS_REGEX    = BUNDLESET_PLUS_REGEX
+    VOLSET_PLUS_REGEX_I  = BUNDLESET_PLUS_REGEX_I
+    VOLNAME_REGEX        = BUNDLENAME_REGEX
+    VOLNAME_REGEX_I      = BUNDLENAME_REGEX_I
+    VOLNAME_PLUS_REGEX   = BUNDLENAME_PLUS_REGEX
+    VOLNAME_PLUS_REGEX_I = BUNDLENAME_PLUS_REGEX_I
+    VOLNAME_VERSION      = BUNDLENAME_VERSION
+    VOLNAME_VERSION_I    = BUNDLENAME_VERSION_I
 
     # Logger
     LOGGER = pdslogger.NullLogger()
@@ -119,6 +156,73 @@ class Pds3File(PdsFile):
         else:
             return ('Pds3File.' + type(self).__name__ + '("' +
                     self.abspath + '")')
+
+    @property
+    def volset(self):
+        return self.bundleset
+
+    @property
+    def volset_(self):
+        return self.bundleset_
+
+    @property
+    def is_volset(self):
+        return self.is_bundleset
+
+    @property
+    def is_volset_dir(self):
+        return self.is_bundleset_dir
+
+    @property
+    def is_volset_file(self):
+        return self.is_bundleset_file
+
+    @property
+    def volname(self):
+        return self.bundlename
+
+    @property
+    def volname_(self):
+        return self.bundlename_
+
+    @property
+    def is_volume(self):
+        return self.is_bundle
+
+    @property
+    def is_volume_dir(self):
+        return self.is_bundle_dir
+
+    @property
+    def is_volume_file(self):
+        return self.is_bundle_file
+
+    def log_path_for_volume(self, suffix='', task='', dir='', place='default'):
+        return self.log_path_for_bundle(suffix=suffix, task=task, dir=dir, place=place)
+
+#     def volset_abspath(self):
+#         return self.bundleset_abspath()
+#
+#     def volset_pdsfile(self):
+#         return self.bundleset_pdsfile()
+#
+#     def volume_abspath(self):
+#         return self.bundle_abspath()
+#
+#     def volume_pdsfile(self):
+#         return self.bundle_pdsfile()
+#
+#     @property
+#     def voltype_(self):
+#         return self.bundletype_
+#
+#     @property
+#     def volume_publication_date(self):
+#         return self.bundle_publication_date
+#
+#     @property
+#     def volume_version_id(self):
+#         return self.bundle_version_id
 
     ######################################################################################
     # PdsLogger support


### PR DESCRIPTION
- I duplicated the "BUNDLE" regular expressions of PdsFile into Pds3File. In the end, they really don't belong in PdsFile; instead, there should be a set of parallel definitions in Pds4File that specify different rules that are appropriate for the new standard. However, for now, I did not remove those definitions from PdsFile, so this should not break anything.
- BTW, I am assuming no one will ever create an instance of PdsFile. It should be an abstract class that merely serves as the superclass of Pds3File and Pds4File, containing all the source code that Pds3File and Pds4File share. Meanwhile, `pds3file/__init__.py` and `pds4file/__init__.py` will contain only the source code that is unique to each subclass. Ideally, the constructor for PdsFile should immediately raise an exception. If you are not thinking of PdsFile in this way, we should discuss it.
- In `pds3file/__init__.py`, I added some of the "aliases" we discussed recently in the Slack channel, using "vol" in place of "bundle". This includes the aforementioned regular expressions. These are additions to the file so they shouldn't break anything.
- `pdsdependency.py` had some broken regular expressions for specifying the New Horizons browse products, so these were not being checked properly. That is now fixed.
- `re-validate.py` stopped working for me, apparently having something to do with refererences to PdsFile that should have been references to Pds3File. I did not pursue this question very far; I just made sufficient changes for `re-validate` to work again.
- Note that we _might_ be able to eventually have versions of all the maintenance programs that support both PDS3 and PDS4. However, until we do, I strongly prefer to keep the PDS3 source code referring to "volumes" instead of "bundles". I made that change back to how things looked previously.
- I found a set of holdings errors where certain PDS3 label files did not have the "CR-LF" line terminators that the PDS3 standard required. I decided to create a somewhat quick-and-dirty program `crlf.py` that can check or repair line terminators. It is now in the `maintenance/pds3` subdirectory.
- BTW, I am submitting these changes from my laptop. I am not sure the correct way to propagate these changes to Admin but I need them there for validation to work correctly going forward. For now, that is just a manual copy. After the merge, we'll have to do a fresh pull and whatever "pip installs" are required.
