### PR TITLE
Annoyingly, there are directories with files containing '_old' that s…

### DIFF
--- a/holdings_maintenance/pds3/pdsarchives.py
+++ b/holdings_maintenance/pds3/pdsarchives.py
@@ -28,7 +28,7 @@ WRITE_ARCHIVE_LIMITS = {'info': -1, 'dot_': 100}
 VALIDATE_TUPLES_LIMITS = {'info': 100}
 
 BACKUP_FILENAME = re.compile(r'.*[-_](20\d\d-\d\d-\d\dT\d\d-\d\d-\d\d'
-                             r'|backup|original|old)\.[\w.]+$')
+                             r'|backup|original)\.[\w.]+$')
 
 ################################################################################
 # General tarfile functions

--- a/holdings_maintenance/pds3/pdschecksums.py
+++ b/holdings_maintenance/pds3/pdschecksums.py
@@ -33,7 +33,7 @@ WRITE_CHECKSUMS_LIMITS = {'dot_': -1, 'ds_store': -1, 'invisible': 100}
 VALIDATE_PAIRS_LIMITS = {}
 
 BACKUP_FILENAME = re.compile(r'.*[-_](20\d\d-\d\d-\d\dT\d\d-\d\d-\d\d'
-                             r'|backup|original|old)\.[\w.]+$')
+                             r'|backup|original)\.[\w.]+$')
 
 ################################################################################
 

--- a/holdings_maintenance/pds3/pdsdependency.py
+++ b/holdings_maintenance/pds3/pdsdependency.py
@@ -22,7 +22,7 @@ LOGNAME = 'pds.validation.dependencies'
 LOGROOT_ENV = 'PDS_LOG_ROOT'
 
 BACKUP_FILENAME = re.compile(r'.*[-_](20\d\d-\d\d-\d\dT\d\d-\d\d-\d\d'
-                             r'|backup|original|old)\.[\w.]+$')
+                             r'|backup|original)\.[\w.]+$')
 
 ################################################################################
 # Translator for tests to apply

--- a/holdings_maintenance/pds3/pdsindexshelf.py
+++ b/holdings_maintenance/pds3/pdsindexshelf.py
@@ -29,7 +29,7 @@ WRITE_INDEXDICT_LIMITS = {}
 LOAD_INDEXDICT_LIMITS = {}
 
 BACKUP_FILENAME = re.compile(r'.*[-_](20\d\d-\d\d-\d\dT\d\d-\d\d-\d\d'
-                             r'|backup|original|old)\.[\w.]+$')
+                             r'|backup|original)\.[\w.]+$')
 
 ################################################################################
 

--- a/holdings_maintenance/pds3/pdsinfoshelf.py
+++ b/holdings_maintenance/pds3/pdsinfoshelf.py
@@ -42,7 +42,7 @@ LOAD_INFODICT_LIMITS = {}
 WRITE_INFODICT_LIMITS = {}
 
 BACKUP_FILENAME = re.compile(r'.*[-_](20\d\d-\d\d-\d\dT\d\d-\d\d-\d\d'
-                             r'|backup|original|old)\.[\w.]+$')
+                             r'|backup|original)\.[\w.]+$')
 
 ################################################################################
 

--- a/holdings_maintenance/pds3/pdslinkshelf.py
+++ b/holdings_maintenance/pds3/pdslinkshelf.py
@@ -34,7 +34,7 @@ WRITE_LINKDICT_LIMITS = {}
 VALIDATE_LINKS_LIMITS = {}
 
 BACKUP_FILENAME = re.compile(r'.*[-_](20\d\d-\d\d-\d\dT\d\d-\d\d-\d\d'
-                             r'|backup|original|old)\.[\w.]+$')
+                             r'|backup|original)\.[\w.]+$')
 
 REPAIRS = translator.TranslatorByRegex([
 


### PR DESCRIPTION
…upposed to be there.

Last night's re-validate broke because there are some directories on COISS_0011 that contain files that end with "_old". I had assumed any file containing "_old" was our error, not really supposed to be part of the holdings, so the updates to the validation tools logged them as errors. I was wrong. Sorry about this.