### PR TITLE
from Mark, bug fix in pdslinkshelf.py

### DIFF
--- a/holdings_maintenance/pds3/pdslinkshelf.py
+++ b/holdings_maintenance/pds3/pdslinkshelf.py
@@ -1479,6 +1479,7 @@ def repair(pdsdir, *, logger=None, limits={}):
         logger = logger or pdslogger.PdsLogger.get_logger(LOGNAME)
         logger.warning('Link shelf file does not exist; initializing',
                        link_path)
+        initialize(pdsdir, logger=logger, limits=limits)
         return
 
     # Read link shelf file


### PR DESCRIPTION
pdslinkshelf --repair had a bug where it would say that it was initializing a linkshelf file but it wouldn't. Fixed. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR fixes a bug in pdslinkshelf.py where the system would report initializing a linkshelf file without actually doing so. The update adds a proper call to the initialize function, improving the reliability of the pdslinkshelf --repair functionality and ensuring correct behavior when the linkshelf file is missing.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>