### PR TITLE
Delete ._* files after each rsync call

### DIFF
--- a/holdings_maintenance/pds3/pdsdata-sync-volset-metadata-versions.sh
+++ b/holdings_maintenance/pds3/pdsdata-sync-volset-metadata-versions.sh
@@ -33,7 +33,7 @@ do
     rsync -av ${ARG1} ${ARG2} --exclude=".DS_Store" --exclude="._*" \
           /Volumes/pdsdata-${SRC}/holdings/archives-${TYPE}/${VOLSET}* \
           /Volumes/pdsdata-${DEST}/holdings/archives-${TYPE}/
-    find /Volumes/pdsdata-${DEST}/holdings/archives-${TYPE}/${VOLSET}/ -name "._*" -delete
+    find /Volumes/pdsdata-${DEST}/holdings/archives-${TYPE}/ -name "._*" -delete
 
     echo "\n\n**** holdings/checksums-${TYPE}/${VOLSET}* ****"
     rsync -av ${ARG1} ${ARG2} --exclude=".DS_Store" --exclude="._*" \

--- a/holdings_maintenance/pds3/pdsdata-sync-volset-metadata-versions.sh
+++ b/holdings_maintenance/pds3/pdsdata-sync-volset-metadata-versions.sh
@@ -33,11 +33,13 @@ do
     rsync -av ${ARG1} ${ARG2} --exclude=".DS_Store" --exclude="._*" \
           /Volumes/pdsdata-${SRC}/holdings/archives-${TYPE}/${VOLSET}* \
           /Volumes/pdsdata-${DEST}/holdings/archives-${TYPE}/
+    find /Volumes/pdsdata-${DEST}/holdings/archives-${TYPE}/${VOLSET}/ -name "._*" -delete
 
     echo "\n\n**** holdings/checksums-${TYPE}/${VOLSET}* ****"
     rsync -av ${ARG1} ${ARG2} --exclude=".DS_Store" --exclude="._*" \
           /Volumes/pdsdata-${SRC}/holdings/checksums-${TYPE}/${VOLSET}* \
           /Volumes/pdsdata-${DEST}/holdings/checksums-${TYPE}/
+    find /Volumes/pdsdata-${DEST}/holdings/checksums-${TYPE}/ -name "._*" -delete
 
     echo "\n\n**** holdings/checksums-archives-${TYPE}/${VOLSET}*_md5.txt ****"
     rsync -av ${ARG1} ${ARG2} \
@@ -45,11 +47,13 @@ do
           --exclude="*" \
           /Volumes/pdsdata-${SRC}/holdings/checksums-archives-${TYPE}/ \
           /Volumes/pdsdata-${DEST}/holdings/checksums-archives-${TYPE}/
+    find /Volumes/pdsdata-${DEST}/holdings/checksums-archives-${TYPE}/ -name "._*" -delete
 
     echo "\n\n**** holdings/_infoshelf-${TYPE}/${VOLSET}* ****"
     rsync -av ${ARG1} ${ARG2} --exclude=".DS_Store" --exclude="._*" \
           /Volumes/pdsdata-${SRC}/holdings/_infoshelf-${TYPE}/${VOLSET}* \
           /Volumes/pdsdata-${DEST}/holdings/_infoshelf-${TYPE}/
+    find /Volumes/pdsdata-${DEST}/holdings/_infoshelf-${TYPE}/ -name "._*" -delete
 
     echo "\n\n**** holdings/_infoshelf-archives-${TYPE}/${VOLSET}*_info.py ****"
     rsync -av ${ARG1} ${ARG2} \
@@ -57,12 +61,14 @@ do
           --exclude="*" \
           /Volumes/pdsdata-${SRC}/holdings/_infoshelf-archives-${TYPE}/ \
           /Volumes/pdsdata-${DEST}/holdings/_infoshelf-archives-${TYPE}/
+    find /Volumes/pdsdata-${DEST}/holdings/_infoshelf-archives-${TYPE}/ -name "._*" -delete
 
     if [ -d /Volumes/pdsdata-${SRC}/holdings/_linkshelf-${TYPE}/${VOLSET} ]; then
       echo "\n\n**** holdings/_linkshelf-${TYPE}/${VOLSET}* ****"
       rsync -av ${ARG1} ${ARG2} --exclude=".DS_Store" --exclude="._*" \
             /Volumes/pdsdata-${SRC}/holdings/_linkshelf-${TYPE}/${VOLSET}* \
             /Volumes/pdsdata-${DEST}/holdings/_linkshelf-${TYPE}/
+      find /Volumes/pdsdata-${DEST}/holdings/_linkshelf-${TYPE}/ -name "._*" -delete
     fi
 
     if [ -d /Volumes/pdsdata-${SRC}/holdings/_indexshelf-${TYPE}/${VOLSET} ]; then
@@ -70,13 +76,14 @@ do
       rsync -av ${ARG1} ${ARG2} --exclude=".DS_Store" --exclude="._*" \
             /Volumes/pdsdata-${SRC}/holdings/_indexshelf-${TYPE}/${VOLSET}* \
             /Volumes/pdsdata-${DEST}/holdings/_indexshelf-${TYPE}/
+      find /Volumes/pdsdata-${DEST}/holdings/_indexshelf-${TYPE}/ -name "._*" -delete
     fi
 
     echo "\n\n**** holdings/${TYPE}/${VOLSET}* ****"
     rsync -av ${ARG1} ${ARG2} --exclude=".DS_Store" --exclude="._*" \
           /Volumes/pdsdata-${SRC}/holdings/${TYPE}/${VOLSET}* \
           /Volumes/pdsdata-${DEST}/holdings/${TYPE}/
-
+    find /Volumes/pdsdata-${DEST}/holdings/${TYPE}/ -name "._*" -delete
   fi
 done
 
@@ -85,6 +92,7 @@ if [ -f /Volumes/pdsdata-${SRC}/holdings/_volinfo/${VOLSET}.txt ]; then
   rsync -av ${ARG1} ${ARG2} --include="${VOLSET}.txt" --exclude="*" \
         /Volumes/pdsdata-${SRC}/holdings/_volinfo/ \
         /Volumes/pdsdata-${DEST}/holdings/_volinfo/
+  find /Volumes/pdsdata-${DEST}/holdings/_volinfo/ -name "._*" -delete
 fi
 
 if [ -d /Volumes/pdsdata-${SRC}/holdings/documents/${VOLSET} ]; then
@@ -92,6 +100,7 @@ if [ -d /Volumes/pdsdata-${SRC}/holdings/documents/${VOLSET} ]; then
   rsync -av ${ARG1} ${ARG2} --exclude=".DS_Store" --exclude="._*" \
         /Volumes/pdsdata-${SRC}/holdings/documents/${VOLSET}/ \
         /Volumes/pdsdata-${DEST}/holdings/documents/${VOLSET}/
+  find /Volumes/pdsdata-${DEST}/holdings/documents/${VOLSET}/ -name "._*" -delete
 fi
 
 #########################################################################################

--- a/holdings_maintenance/pds3/pdsdata-sync-volset-metadata.sh
+++ b/holdings_maintenance/pds3/pdsdata-sync-volset-metadata.sh
@@ -31,11 +31,13 @@ do
     rsync -av ${ARG1} ${ARG2} --exclude=".DS_Store" --exclude="._*" \
           /Volumes/pdsdata-${SRC}/holdings/archives-${TYPE}/${VOLSET}/ \
           /Volumes/pdsdata-${DEST}/holdings/archives-${TYPE}/${VOLSET}/
+    find /Volumes/pdsdata-${DEST}/holdings/archives-${TYPE}/${VOLSET}/ -name "._*" -delete
 
     echo "\n\n**** holdings/checksums-${TYPE}/${VOLSET} ****"
     rsync -av ${ARG1} ${ARG2} --exclude=".DS_Store" --exclude="._*" \
           /Volumes/pdsdata-${SRC}/holdings/checksums-${TYPE}/${VOLSET}/ \
           /Volumes/pdsdata-${DEST}/holdings/checksums-${TYPE}/${VOLSET}/
+    find /Volumes/pdsdata-${DEST}/holdings/checksums-${TYPE}/${VOLSET}/ -name "._*" -delete
 
     echo "\n\n**** holdings/checksums-archives-${TYPE}/${VOLSET}_*md5.txt ****"
     rsync -av ${ARG1} ${ARG2} \
@@ -43,11 +45,13 @@ do
         --exclude="*" \
         /Volumes/pdsdata-${SRC}/holdings/checksums-archives-${TYPE}/ \
         /Volumes/pdsdata-${DEST}/holdings/checksums-archives-${TYPE}/
+    find /Volumes/pdsdata-${DEST}/holdings/checksums-archives-${TYPE}/ -name "._*" -delete
 
     echo "\n\n**** holdings/_infoshelf-${TYPE}/${VOLSET} ****"
     rsync -av ${ARG1} ${ARG2} --exclude=".DS_Store" --exclude="._*" \
           /Volumes/pdsdata-${SRC}/holdings/_infoshelf-${TYPE}/${VOLSET}/ \
           /Volumes/pdsdata-${DEST}/holdings/_infoshelf-${TYPE}/${VOLSET}/
+    find /Volumes/pdsdata-${DEST}/holdings/_infoshelf-${TYPE}/${VOLSET}/ -name "._*" -delete
 
     echo "\n\n**** holdings/_infoshelf-archives-${TYPE}/${VOLSET}_info.py ****"
     rsync -av ${ARG1} ${ARG2} \
@@ -55,12 +59,14 @@ do
           --exclude="*" \
           /Volumes/pdsdata-${SRC}/holdings/_infoshelf-archives-${TYPE}/ \
           /Volumes/pdsdata-${DEST}/holdings/_infoshelf-archives-${TYPE}/
+    find /Volumes/pdsdata-${DEST}/holdings/_infoshelf-archives-${TYPE}/ -name "._*" -delete
 
     if [ -d /Volumes/pdsdata-${SRC}/holdings/_linkshelf-${TYPE}/${VOLSET} ]; then
       echo "\n\n**** holdings/_linkshelf-${TYPE}/${VOLSET} ****"
       rsync -av ${ARG1} ${ARG2} --exclude=".DS_Store" --exclude="._*" \
             /Volumes/pdsdata-${SRC}/holdings/_linkshelf-${TYPE}/${VOLSET}/ \
             /Volumes/pdsdata-${DEST}/holdings/_linkshelf-${TYPE}/${VOLSET}/
+      find /Volumes/pdsdata-${DEST}/holdings/_linkshelf-${TYPE}/${VOLSET}/ -name "._*" -delete
     fi
 
     if [ -d /Volumes/pdsdata-${SRC}/holdings/_indexshelf-${TYPE}/${VOLSET} ]; then
@@ -68,13 +74,14 @@ do
       rsync -av ${ARG1} ${ARG2} --exclude=".DS_Store" --exclude="._*" \
             /Volumes/pdsdata-${SRC}/holdings/_indexshelf-${TYPE}/${VOLSET}/ \
             /Volumes/pdsdata-${DEST}/holdings/_indexshelf-${TYPE}/${VOLSET}/
+      find /Volumes/pdsdata-${DEST}/holdings/_indexshelf-${TYPE}/${VOLSET}/ -name "._*" -delete
     fi
 
     echo "\n\n**** holdings/${TYPE}/${VOLSET} ****"
     rsync -av ${ARG1} ${ARG2} --exclude=".DS_Store" --exclude="._*" \
           /Volumes/pdsdata-${SRC}/holdings/${TYPE}/${VOLSET}/ \
           /Volumes/pdsdata-${DEST}/holdings/${TYPE}/${VOLSET}/
-
+    find /Volumes/pdsdata-${DEST}/holdings/${TYPE}/${VOLSET}/ -name "._*" -delete
   fi
 done
 
@@ -83,6 +90,7 @@ if [ -f /Volumes/pdsdata-${SRC}/holdings/_volinfo/${VOLSET}.txt ]; then
   rsync -av ${ARG1} ${ARG2} --include="${VOLSET}.txt" --exclude="*" \
         /Volumes/pdsdata-${SRC}/holdings/_volinfo/ \
         /Volumes/pdsdata-${DEST}/holdings/_volinfo/
+  find /Volumes/pdsdata-${DEST}/holdings/_volinfo/ -name "._*" -delete
 fi
 
 if [ -d /Volumes/pdsdata-${SRC}/holdings/documents/${VOLSET} ]; then
@@ -90,6 +98,7 @@ if [ -d /Volumes/pdsdata-${SRC}/holdings/documents/${VOLSET} ]; then
   rsync -av ${ARG1} ${ARG2} --exclude=".DS_Store" --exclude="._*" \
         /Volumes/pdsdata-${SRC}/holdings/documents/${VOLSET}/ \
         /Volumes/pdsdata-${DEST}/holdings/documents/${VOLSET}/
+  find /Volumes/pdsdata-${DEST}/holdings/documents/${VOLSET}/ -name "._*" -delete
 fi
 
 #########################################################################################

--- a/holdings_maintenance/pds3/pdsdata-sync-volset-previews.sh
+++ b/holdings_maintenance/pds3/pdsdata-sync-volset-previews.sh
@@ -32,11 +32,13 @@ do
     rsync -av ${ARG1} ${ARG2} --exclude=".DS_Store" --exclude="._*" \
           /Volumes/pdsdata-${SRC}/holdings/archives-${TYPE}/${VOLSET}/ \
           /Volumes/pdsdata-${DEST}/holdings/archives-${TYPE}/${VOLSET}/
+    find /Volumes/pdsdata-${DEST}/holdings/archives-${TYPE}/${VOLSET}/ -name "._*" -delete
 
     echo "\n\n**** holdings/checksums-${TYPE}/${VOLSET} ****"
     rsync -av ${ARG1} ${ARG2} --exclude=".DS_Store" --exclude="._*" \
           /Volumes/pdsdata-${SRC}/holdings/checksums-${TYPE}/${VOLSET}/ \
           /Volumes/pdsdata-${DEST}/holdings/checksums-${TYPE}/${VOLSET}/
+    find /Volumes/pdsdata-${DEST}/holdings/checksums-${TYPE}/${VOLSET}/ -name "._*" -delete
 
     echo "\n\n**** holdings/checksums-archives-${TYPE}/${VOLSET}_*md5.txt ****"
     rsync -av ${ARG1} ${ARG2} \
@@ -44,11 +46,13 @@ do
           --exclude="*" \
           /Volumes/pdsdata-${SRC}/holdings/checksums-archives-${TYPE}/ \
           /Volumes/pdsdata-${DEST}/holdings/checksums-archives-${TYPE}/
+    find /Volumes/pdsdata-${DEST}/holdings/checksums-archives-${TYPE}/ -name "._*" -delete
 
     echo "\n\n**** holdings/_infoshelf-${TYPE}/${VOLSET} ****"
     rsync -av ${ARG1} ${ARG2} --exclude=".DS_Store" --exclude="._*" \
           /Volumes/pdsdata-${SRC}/holdings/_infoshelf-${TYPE}/${VOLSET}/ \
           /Volumes/pdsdata-${DEST}/holdings/_infoshelf-${TYPE}/${VOLSET}/
+    find /Volumes/pdsdata-${DEST}/holdings/_infoshelf-${TYPE}/${VOLSET}/ -name "._*" -delete
 
     echo "\n\n**** holdings/_infoshelf-archives-${TYPE}/${VOLSET}_info.py ****"
     rsync -av ${ARG1} ${ARG2} \
@@ -56,12 +60,14 @@ do
           --exclude="*" \
           /Volumes/pdsdata-${SRC}/holdings/_infoshelf-archives-${TYPE}/ \
           /Volumes/pdsdata-${DEST}/holdings/_infoshelf-archives-${TYPE}/
+    find /Volumes/pdsdata-${DEST}/holdings/_infoshelf-archives-${TYPE}/ -name "._*" -delete
 
     if [ -d /Volumes/pdsdata-${SRC}/holdings/_linkshelf-${TYPE}/${VOLSET} ]; then
       echo "\n\n**** holdings/_linkshelf-${TYPE}/${VOLSET} ****"
       rsync -av ${ARG1} ${ARG2} --exclude=".DS_Store" --exclude="._*" \
             /Volumes/pdsdata-${SRC}/holdings/_linkshelf-${TYPE}/${VOLSET}/ \
             /Volumes/pdsdata-${DEST}/holdings/_linkshelf-${TYPE}/${VOLSET}/
+      find /Volumes/pdsdata-${DEST}/holdings/_linkshelf-${TYPE}/${VOLSET}/ -name "._*" -delete
     fi
 
     if [ -d /Volumes/pdsdata-${SRC}/holdings/_indexshelf-${TYPE}/${VOLSET} ]; then
@@ -69,13 +75,14 @@ do
       rsync -av ${ARG1} ${ARG2} --exclude=".DS_Store" --exclude="._*" \
             /Volumes/pdsdata-${SRC}/holdings/_indexshelf-${TYPE}/${VOLSET}/ \
             /Volumes/pdsdata-${DEST}/holdings/_indexshelf-${TYPE}/${VOLSET}/
+      find /Volumes/pdsdata-${DEST}/holdings/_indexshelf-${TYPE}/${VOLSET}/ -name "._*" -delete
     fi
 
     echo "\n\n**** holdings/${TYPE}/${VOLSET} ****"
     rsync -av ${ARG1} ${ARG2} --exclude=".DS_Store" --exclude="._*" \
           /Volumes/pdsdata-${SRC}/holdings/${TYPE}/${VOLSET}/ \
           /Volumes/pdsdata-${DEST}/holdings/${TYPE}/${VOLSET}/
-
+    find /Volumes/pdsdata-${DEST}/holdings/${TYPE}/${VOLSET}/ -name "._*" -delete
   fi
 done
 
@@ -84,6 +91,7 @@ if [ -f /Volumes/pdsdata-${SRC}/holdings/_volinfo/${VOLSET}.txt ]; then
   rsync -av ${ARG1} ${ARG2} --include="${VOLSET}.txt" --exclude="*" \
         /Volumes/pdsdata-${SRC}/holdings/_volinfo/ \
         /Volumes/pdsdata-${DEST}/holdings/_volinfo/
+  find /Volumes/pdsdata-${DEST}/holdings/_volinfo/ -name "._*" -delete
 fi
 
 if [ -d /Volumes/pdsdata-${SRC}/holdings/documents/${VOLSET} ]; then
@@ -91,6 +99,8 @@ if [ -d /Volumes/pdsdata-${SRC}/holdings/documents/${VOLSET} ]; then
   rsync -av ${ARG1} ${ARG2} --exclude=".DS_Store" --exclude="._*" \
         /Volumes/pdsdata-${SRC}/holdings/documents/${VOLSET}/ \
         /Volumes/pdsdata-${DEST}/holdings/documents/${VOLSET}/
+  find /Volumes/pdsdata-${DEST}/holdings/documents/${VOLSET}/ -name "._*" -delete
+>>>>>>> Stashed changes
 fi
 
 #########################################################################################

--- a/holdings_maintenance/pds3/pdsdata-sync-volset-previews.sh
+++ b/holdings_maintenance/pds3/pdsdata-sync-volset-previews.sh
@@ -100,7 +100,6 @@ if [ -d /Volumes/pdsdata-${SRC}/holdings/documents/${VOLSET} ]; then
         /Volumes/pdsdata-${SRC}/holdings/documents/${VOLSET}/ \
         /Volumes/pdsdata-${DEST}/holdings/documents/${VOLSET}/
   find /Volumes/pdsdata-${DEST}/holdings/documents/${VOLSET}/ -name "._*" -delete
->>>>>>> Stashed changes
 fi
 
 #########################################################################################

--- a/holdings_maintenance/pds3/pdsdata-sync-volset.sh
+++ b/holdings_maintenance/pds3/pdsdata-sync-volset.sh
@@ -6,10 +6,9 @@
 # Usage:
 #   pdsdata-sync-volset <old> <new> <volset> [--dry-run] [--delete]
 #
-# Syncs the specified volume set <volset> from the drive /Volumes/pdsdata-<old> to the 
-# drive /Volumes/pdsdata-<new>. Use the "--dry-run" option for a test dry run. Use the 
-# "--delete" option to delete extraneous files in the remote directory. The rsync options 
-# -a (archive) mode and -v (verbose) are included by default.
+# Syncs the specified volume set <volset> from the drive /Volumes/pdsdata-<old>
+# to the drive /Volumes/pdsdata-<new>. Append "--dry-run" for a test dry run.
+# Append "--delete" to delete extraneous files in the remote directory.
 #
 # Example:
 #   pdsdata-sync-volset admin staging VGx_9xxx --delete
@@ -30,11 +29,13 @@ do
     rsync -av ${ARG1} ${ARG2} --exclude=".DS_Store" --exclude="._*" \
           /Volumes/pdsdata-${SRC}/holdings/archives-${TYPE}/${VOLSET}/ \
           /Volumes/pdsdata-${DEST}/holdings/archives-${TYPE}/${VOLSET}/
+    find /Volumes/pdsdata-${DEST}/holdings/archives-${TYPE}/${VOLSET}/ -name "._*" -delete
 
     echo "\n\n**** holdings/checksums-${TYPE}/${VOLSET} ****"
     rsync -av ${ARG1} ${ARG2} --exclude=".DS_Store" --exclude="._*" \
           /Volumes/pdsdata-${SRC}/holdings/checksums-${TYPE}/${VOLSET}/ \
           /Volumes/pdsdata-${DEST}/holdings/checksums-${TYPE}/${VOLSET}/
+    find /Volumes/pdsdata-${DEST}/holdings/checksums-${TYPE}/${VOLSET}/ -name "._*" -delete
 
     echo "\n\n**** holdings/checksums-archives-${TYPE}/${VOLSET}_*md5.txt ****"
     rsync -av ${ARG1} ${ARG2} \
@@ -42,12 +43,14 @@ do
           --exclude="*" \
           /Volumes/pdsdata-${SRC}/holdings/checksums-archives-${TYPE}/ \
           /Volumes/pdsdata-${DEST}/holdings/checksums-archives-${TYPE}/
+    find /Volumes/pdsdata-${DEST}/holdings/checksums-archives-${TYPE}/ -name "._*" -delete
 
     echo "\n\n**** holdings/_infoshelf-${TYPE}/${VOLSET} ****"
     rsync -av ${ARG1} ${ARG2} \
           --exclude=".DS_Store" --exclude="._*" \
           /Volumes/pdsdata-${SRC}/holdings/_infoshelf-${TYPE}/${VOLSET}/ \
           /Volumes/pdsdata-${DEST}/holdings/_infoshelf-${TYPE}/${VOLSET}/
+    find /Volumes/pdsdata-${DEST}/holdings/_infoshelf-${TYPE}/${VOLSET}/ -name "._*" -delete
 
     echo "\n\n**** holdings/_infoshelf-archives-${TYPE}/${VOLSET}_info.py ****"
     rsync -av ${ARG1} ${ARG2} \
@@ -55,12 +58,14 @@ do
           --exclude="*" \
           /Volumes/pdsdata-${SRC}/holdings/_infoshelf-archives-${TYPE}/ \
           /Volumes/pdsdata-${DEST}/holdings/_infoshelf-archives-${TYPE}/
+    find /Volumes/pdsdata-${DEST}/holdings/_infoshelf-archives-${TYPE}/ -name "._*" -delete
 
     if [ -d /Volumes/pdsdata-${SRC}/holdings/_linkshelf-${TYPE}/${VOLSET} ]; then
       echo "\n\n**** holdings/_linkshelf-${TYPE}/${VOLSET} ****"
       rsync -av ${ARG1} ${ARG2} --exclude=".DS_Store" --exclude="._*" \
             /Volumes/pdsdata-${SRC}/holdings/_linkshelf-${TYPE}/${VOLSET}/ \
             /Volumes/pdsdata-${DEST}/holdings/_linkshelf-${TYPE}/${VOLSET}/
+      find /Volumes/pdsdata-${DEST}/holdings/_linkshelf-${TYPE}/${VOLSET}/ -name "._*" -delete
     fi
 
     if [ -d /Volumes/pdsdata-${SRC}/holdings/_indexshelf-${TYPE}/${VOLSET} ]; then
@@ -68,13 +73,14 @@ do
       rsync -av ${ARG1} ${ARG2} --exclude=".DS_Store" --exclude="._*" \
             /Volumes/pdsdata-${SRC}/holdings/_indexshelf-${TYPE}/${VOLSET}/ \
             /Volumes/pdsdata-${DEST}/holdings/_indexshelf-${TYPE}/${VOLSET}/
+      find /Volumes/pdsdata-${DEST}/holdings/_indexshelf-${TYPE}/${VOLSET}/ -name "._*" -delete
     fi
 
     echo "\n\n**** holdings/${TYPE}/${VOLSET} ****"
     rsync -av ${ARG1} ${ARG2} --exclude=".DS_Store" --exclude="._*" \
           /Volumes/pdsdata-${SRC}/holdings/${TYPE}/${VOLSET}/ \
           /Volumes/pdsdata-${DEST}/holdings/${TYPE}/${VOLSET}/
-
+    find /Volumes/pdsdata-${DEST}/holdings/${TYPE}/${VOLSET}/ -name "._*" -delete
   fi
 done
 
@@ -83,6 +89,7 @@ if [ -f /Volumes/pdsdata-${SRC}/holdings/_volinfo/${VOLSET}.txt ]; then
   rsync -av ${ARG1} ${ARG2} --include="${VOLSET}.txt" --exclude="*" \
         /Volumes/pdsdata-${SRC}/holdings/_volinfo/ \
         /Volumes/pdsdata-${DEST}/holdings/_volinfo/
+  find /Volumes/pdsdata-${DEST}/holdings/_volinfo/ -name "._*" -delete
 fi
 
 if [ -d /Volumes/pdsdata-${SRC}/holdings/documents/${VOLSET} ]; then
@@ -90,6 +97,7 @@ if [ -d /Volumes/pdsdata-${SRC}/holdings/documents/${VOLSET} ]; then
   rsync -av ${ARG1} ${ARG2} --exclude=".DS_Store" --exclude="._*" \
         /Volumes/pdsdata-${SRC}/holdings/documents/${VOLSET}/ \
         /Volumes/pdsdata-${DEST}/holdings/documents/${VOLSET}/
+  find /Volumes/pdsdata-${DEST}/holdings/documents/${VOLSET}/ -name "._*" -delete
 fi
 
 echo

--- a/holdings_maintenance/pds3/pdsdata-sync-volume-metadata.sh
+++ b/holdings_maintenance/pds3/pdsdata-sync-volume-metadata.sh
@@ -34,13 +34,15 @@ do
           --exclude="*" \
           /Volumes/pdsdata-${SRC}/holdings/archives-${TYPE}/${VOLSET}/ \
           /Volumes/pdsdata-${DEST}/holdings/archives-${TYPE}/${VOLSET}/
+    find /Volumes/pdsdata-${DEST}/holdings/archives-${TYPE}/${VOLSET}/ -name "._*" -delete
 
     echo "\n\n**** holdings/checksums-${TYPE}/${VOLSET}/${VOLUME}*_md5.txt ****"
     rsync -av ${ARG1} ${ARG2} \
           --include="${VOLUME}_md5.txt" --include="${VOLUME}_${TYPE}_md5.txt" \
           --exclude="*" \
           /Volumes/pdsdata-${SRC}/holdings/checksums-${TYPE}/${VOLSET}/ \
-          /Volumes/pdsdata-${DEST}/holdings/checksums-${TYPE}/${VOLSET}/ 
+          /Volumes/pdsdata-${DEST}/holdings/checksums-${TYPE}/${VOLSET}/
+    find /Volumes/pdsdata-${DEST}/holdings/checksums-${TYPE}/${VOLSET}/ -name "._*" -delete
 
     echo "\n\n**** holdings/checksums-archives-${TYPE}/${VOLSET}_*md5.txt ****"
     rsync -av ${ARG1} ${ARG2} \
@@ -48,6 +50,7 @@ do
           --exclude="*" \
           /Volumes/pdsdata-${SRC}/holdings/checksums-archives-${TYPE}/ \
           /Volumes/pdsdata-${DEST}/holdings/checksums-archives-${TYPE}/
+    find /Volumes/pdsdata-${DEST}/holdings/checksums-archives-${TYPE}/ -name "._*" -delete
 
     echo "\n\n**** holdings/_infoshelf-${TYPE}/${VOLSET}/${VOLUME}_info.* ****"
     rsync -av ${ARG1} ${ARG2} \
@@ -55,6 +58,7 @@ do
           --exclude="*" \
           /Volumes/pdsdata-${SRC}/holdings/_infoshelf-${TYPE}/${VOLSET}/ \
           /Volumes/pdsdata-${DEST}/holdings/_infoshelf-${TYPE}/${VOLSET}/
+    find /Volumes/pdsdata-${DEST}/holdings/_infoshelf-${TYPE}/${VOLSET}/ -name "._*" -delete
 
     echo "\n\n**** holdings/_infoshelf-archives-${TYPE}/${VOLSET}_info.* ****"
     rsync -av ${ARG1} ${ARG2} \
@@ -62,6 +66,7 @@ do
           --exclude="*" \
           /Volumes/pdsdata-${SRC}/holdings/_infoshelf-archives-${TYPE}/ \
           /Volumes/pdsdata-${DEST}/holdings/_infoshelf-archives-${TYPE}/
+    find /Volumes/pdsdata-${DEST}/holdings/_infoshelf-archives-${TYPE}/ -name "._*" -delete
 
     if [ -d /Volumes/pdsdata-${SRC}/holdings/_linkshelf-${TYPE}/${VOLSET} ]; then
       echo "\n\n**** holdings/_linkshelf-${TYPE}/${VOLSET}/${VOLUME}_links.* ****"
@@ -70,6 +75,7 @@ do
             --exclude="*" \
             /Volumes/pdsdata-${SRC}/holdings/_linkshelf-${TYPE}/${VOLSET}/ \
             /Volumes/pdsdata-${DEST}/holdings/_linkshelf-${TYPE}/${VOLSET}/
+      find /Volumes/pdsdata-${DEST}/holdings/_linkshelf-${TYPE}/${VOLSET}/ -name "._*" -delete
     fi
 
     if [ -d /Volumes/pdsdata-${SRC}/holdings/_indexshelf-${TYPE}/${VOLSET} ]; then
@@ -78,6 +84,7 @@ do
             --exclude=".DS_Store" --exclude="._*" \
             /Volumes/pdsdata-${SRC}/holdings/_indexshelf-${TYPE}/${VOLSET}/${VOLUME}/ \
             /Volumes/pdsdata-${DEST}/holdings/_indexshelf-${TYPE}/${VOLSET}/${VOLUME}/
+      find /Volumes/pdsdata-${DEST}/holdings/_indexshelf-${TYPE}/${VOLSET}/${VOLUME}/ -name "._*" -delete
     fi
 
     if [ -d /Volumes/pdsdata-${SRC}/holdings/${TYPE}/${VOLSET} ]; then
@@ -86,6 +93,7 @@ do
             --exclude=".DS_Store" --exclude="._*" \
             /Volumes/pdsdata-${SRC}/holdings/${TYPE}/${VOLSET}/${VOLUME}/ \
             /Volumes/pdsdata-${DEST}/holdings/${TYPE}/${VOLSET}/${VOLUME}/
+      find /Volumes/pdsdata-${DEST}/holdings/${TYPE}/${VOLSET}/${VOLUME}/ -name "._*" -delete
     fi
 
   fi
@@ -97,6 +105,7 @@ if [ -f /Volumes/pdsdata-${SRC}/holdings/_volinfo/${VOLSET}.txt ]; then
         --include="${VOLSET}.txt" --exclude="*" \
         /Volumes/pdsdata-${SRC}/holdings/_volinfo/ \
         /Volumes/pdsdata-${DEST}/holdings/_volinfo/
+  find /Volumes/pdsdata-${DEST}/holdings/_volinfo/ -name "._*" -delete
 fi
 
 if [ -d /Volumes/pdsdata-${SRC}/holdings/documents/${VOLSET} ]; then
@@ -104,6 +113,7 @@ if [ -d /Volumes/pdsdata-${SRC}/holdings/documents/${VOLSET} ]; then
   rsync -av ${ARG1} ${ARG2} --exclude=".DS_Store" --exclude="._*" \
         /Volumes/pdsdata-${SRC}/holdings/documents/${VOLSET}/ \
         /Volumes/pdsdata-${DEST}/holdings/documents/${VOLSET}/
+  find /Volumes/pdsdata-${DEST}/holdings/documents/${VOLSET}/ -name "._*" -delete
 fi
 
 #########################################################################################

--- a/holdings_maintenance/pds3/pdsdata-sync-volume.sh
+++ b/holdings_maintenance/pds3/pdsdata-sync-volume.sh
@@ -33,30 +33,35 @@ do
           --include="${VOLUME}_${TYPE}.tar.gz" --exclude="*" \
           /Volumes/pdsdata-${SRC}/holdings/archives-${TYPE}/${VOLSET}/ \
           /Volumes/pdsdata-${DEST}/holdings/archives-${TYPE}/${VOLSET}/
+    find /Volumes/pdsdata-${DEST}/holdings/archives-${TYPE}/${VOLSET}/ -name "._*" -delete
 
     echo "\n\n**** holdings/checksums-${TYPE}/${VOLSET}/${VOLUME}*_md5.txt ****"
     rsync -av ${ARG1} ${ARG2} --include="${VOLUME}_md5.txt" \
           --include="${VOLUME}_${TYPE}_md5.txt" --exclude="*" \
           /Volumes/pdsdata-${SRC}/holdings/checksums-${TYPE}/${VOLSET}/ \
           /Volumes/pdsdata-${DEST}/holdings/checksums-${TYPE}/${VOLSET}/
+    find /Volumes/pdsdata-${DEST}/holdings/checksums-${TYPE}/${VOLSET}/ -name "._*" -delete
 
     echo "\n\n**** holdings/checksums-archives-${TYPE}/${VOLSET}_*md5.txt ****"
     rsync -av ${ARG1} ${ARG2} --include="${VOLSET}_md5.txt" \
           --include="${VOLSET}_${TYPE}_md5.txt" --exclude="*" \
           /Volumes/pdsdata-${SRC}/holdings/checksums-archives-${TYPE}/ \
           /Volumes/pdsdata-${DEST}/holdings/checksums-archives-${TYPE}/
+    find /Volumes/pdsdata-${DEST}/holdings/checksums-archives-${TYPE}/ -name "._*" -delete
 
     echo "\n\n**** holdings/_infoshelf-${TYPE}/${VOLSET}/${VOLUME}_info.* ****"
     rsync -av ${ARG1} ${ARG2} --include="${VOLUME}_info.py" \
           --include="${VOLUME}_info.pickle" --exclude="*" \
           /Volumes/pdsdata-${SRC}/holdings/_infoshelf-${TYPE}/${VOLSET}/ \
           /Volumes/pdsdata-${DEST}/holdings/_infoshelf-${TYPE}/${VOLSET}/
+    find /Volumes/pdsdata-${DEST}/holdings/_infoshelf-${TYPE}/${VOLSET}/ -name "._*" -delete
 
     echo "\n\n**** holdings/_infoshelf-archives-${TYPE}/${VOLSET}_info.* ****"
     rsync -av ${ARG1} ${ARG2} --include="${VOLSET}_info.py" \
           --include="${VOLSET}_info.pickle" --exclude="*" \
           /Volumes/pdsdata-${SRC}/holdings/_infoshelf-archives-${TYPE}/ \
           /Volumes/pdsdata-${DEST}/holdings/_infoshelf-archives-${TYPE}/
+    find /Volumes/pdsdata-${DEST}/holdings/_infoshelf-archives-${TYPE}/ -name "._*" -delete
 
     if [ -d /Volumes/pdsdata-${SRC}/holdings/_linkshelf-${TYPE}/${VOLSET} ]; then
       echo "\n\n**** holdings/_linkshelf-${TYPE}/${VOLSET}/${VOLUME}_links.* ****"
@@ -64,6 +69,7 @@ do
             --include="${VOLUME}_links.pickle" --exclude="*" \
             /Volumes/pdsdata-${SRC}/holdings/_linkshelf-${TYPE}/${VOLSET}/ \
             /Volumes/pdsdata-${DEST}/holdings/_linkshelf-${TYPE}/${VOLSET}/
+      find /Volumes/pdsdata-${DEST}/holdings/_linkshelf-${TYPE}/${VOLSET}/ -name "._*" -delete
     fi
 
     if [ -d /Volumes/pdsdata-${SRC}/holdings/_indexshelf-${TYPE}/${VOLSET} ]; then
@@ -71,6 +77,7 @@ do
       rsync -av ${ARG1} ${ARG2} --exclude=".DS_Store" --exclude="._*" \
             /Volumes/pdsdata-${SRC}/holdings/_indexshelf-${TYPE}/${VOLSET}/${VOLUME}/ \
             /Volumes/pdsdata-${DEST}/holdings/_indexshelf-${TYPE}/${VOLSET}/${VOLUME}/
+      find /Volumes/pdsdata-${DEST}/holdings/_indexshelf-${TYPE}/${VOLSET}/${VOLUME}/ -name "._*" -delete
     fi
 
     if [ -d /Volumes/pdsdata-${SRC}/holdings/${TYPE}/${VOLSET} ]; then
@@ -78,6 +85,7 @@ do
       rsync -av ${ARG1} ${ARG2} --exclude=".DS_Store" --exclude="._*" \
             /Volumes/pdsdata-${SRC}/holdings/${TYPE}/${VOLSET}/${VOLUME}/ \
             /Volumes/pdsdata-${DEST}/holdings/${TYPE}/${VOLSET}/${VOLUME}/
+      find /Volumes/pdsdata-${DEST}/holdings/${TYPE}/${VOLSET}/${VOLUME}/ -name "._*" -delete
     fi
 
   fi
@@ -88,6 +96,7 @@ if [ -f /Volumes/pdsdata-${SRC}/holdings/_volinfo/${VOLSET}.txt ]; then
   rsync -av ${ARG1} ${ARG2} --include="${VOLSET}.txt" --exclude="*" \
         /Volumes/pdsdata-${SRC}/holdings/_volinfo/ \
         /Volumes/pdsdata-${DEST}/holdings/_volinfo/
+  find /Volumes/pdsdata-${DEST}/holdings/_volinfo/ -name "._*" -delete
 fi
 
 if [ -d /Volumes/pdsdata-${SRC}/holdings/documents/${VOLSET} ]; then
@@ -95,6 +104,7 @@ if [ -d /Volumes/pdsdata-${SRC}/holdings/documents/${VOLSET} ]; then
   rsync -av ${ARG1} ${ARG2} --exclude=".DS_Store" --exclude="._*" \
         /Volumes/pdsdata-${SRC}/holdings/documents/${VOLSET}/ \
         /Volumes/pdsdata-${DEST}/holdings/documents/${VOLSET}/
+  find /Volumes/pdsdata-${DEST}/holdings/documents/${VOLSET}/ -name "._*" -delete
 fi
 
 echo


### PR DESCRIPTION
I've added lines to each of the six syncing scripts that find and delete any `._*` files that appear in the destination directory after the rsync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Remove macOS AppleDouble sidecar files (`._*`) from destinations after synchronization to keep archives and backups free of system metadata.

* **Chores**
  * Added post-sync cleanup across volume- and volset-level maintenance scripts to improve consistency and reduce clutter in synchronized storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->