### PR TITLE
ci: hosted lint/no-holdings job; keep self-hosted full-data gate

### DIFF
--- a/.cursor/rules/pdsfile_overrides.mdc
+++ b/.cursor/rules/pdsfile_overrides.mdc
@@ -9,7 +9,7 @@ These repo-specific decisions were locked with the owner and **take precedence
 over the template `.cursor/rules`**. When a template rule (`python.mdc`,
 `python_testing.mdc`, `dependency_management.mdc`, `filecache.mdc`, etc.)
 conflicts with a rule below, follow the rule below. See
-`plans/2026-07-17-modernization-plan.md` for the full rationale.
+`plans/2026-07-25-modernization-plan.md` for the full rationale.
 
 1. **No inline type annotations and no mypy.** Do not add inline type hints and
    do not run mypy. The public API is documented via a hand-written `.pyi` stub
@@ -47,8 +47,30 @@ conflicts with a rule below, follow the rule below. See
 7. **`pytest` `addopts` carries no `-n`/xdist or `--cov` flags** (unlike the
    template). Worker count and coverage are chosen per invocation, because
    `--update` runs and full-data runs must be serial.
-8. **The CI test matrix is 3-OS** (ubuntu / windows / macos), a deliberate
-   extension of the template's ubuntu-only matrix.
+8. **The CI test matrix is split by what the runner has, not by OS.**
+   `.github/workflows/run-tests.yml` runs two jobs:
+   - a **self-hosted Linux** full-data matrix over Python 3.10, 3.11, 3.12 and
+     3.13, which is the only place the data-dependent suite can run (it needs the
+     real holdings tree, resolved from `PDS3_HOLDINGS_DIR`/`PDS4_HOLDINGS_DIR`);
+   - a **hosted `ubuntu-latest`** lint / no-holdings job over Python 3.10 and 3.13
+     (floor and ceiling only — the self-hosted matrix already covers the two
+     versions in between), which runs `scripts/run-all-checks.sh` with no
+     holdings env vars set. It runs whatever gates that script enables — the
+     script is the single source of truth (`environment.mdc`) — and its pytest
+     gate collects the whole tree, runs the holdings-free subset and skips the
+     rest.
+
+   The two jobs run different drivers, and only their union matches the script's
+   enabled set: the hosted job runs the script itself, while the self-hosted job
+   runs `scripts/automated_tests/pdsfile_main_test.sh`, which adds coverage and a
+   second, pds3-only `--mode s` pass that the script does not have.
+
+   Windows is not in the matrix (dropped because the package is not supported
+   there; its trove classifier is dropped to match). macOS is a supported
+   platform and keeps its classifier — its matrix entries are commented out in
+   the workflow, not deleted, and may be re-enabled. Testing on a stock hosted
+   runner is therefore lint-and-holdings-free only; a data run needs a machine
+   with holdings.
 9. **`logging.mdc`'s "never bare `print()`" is waived for
    `holdings_maintenance/`.** The maintenance tools' console output (including the
    `print()`-driven `shelf_consistency_check`) is frozen behavior.

--- a/.cursor/rules/pdsfile_overrides.mdc
+++ b/.cursor/rules/pdsfile_overrides.mdc
@@ -53,8 +53,8 @@ conflicts with a rule below, follow the rule below. See
      3.13, which is the only place the data-dependent suite can run (it needs the
      real holdings tree, resolved from `PDS3_HOLDINGS_DIR`/`PDS4_HOLDINGS_DIR`);
    - a **hosted `ubuntu-latest`** lint / no-holdings job over Python 3.10 and 3.13
-     (floor and ceiling only — the self-hosted matrix already covers the two
-     versions in between), which runs `scripts/run-all-checks.sh` with no
+     (floor and ceiling only — the self-hosted matrix already covers all four
+     versions with data), which runs `scripts/run-all-checks.sh` with no
      holdings env vars set. It runs whatever gates that script enables — the
      script is the single source of truth (`environment.mdc`) — and its pytest
      gate collects the whole tree, runs the holdings-free subset and skips the

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,6 +16,47 @@ defaults:
     shell: bash
 
 jobs:
+  lint:
+    # Stock GitHub-hosted runners have no holdings tree, so this job is the
+    # everywhere-runnable half of the suite. It runs scripts/run-all-checks.sh
+    # rather than naming individual gates: that script is the single source of
+    # truth for which gates the repository runs (see environment.mdc), so the two
+    # cannot drift. With no holdings env vars set, its pytest gate collects the
+    # whole tree, runs the holdings-free tests and skips the rest. Python floor
+    # and ceiling only; the self-hosted matrix below covers every version with
+    # data.
+    name: Lint and holdings-free tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.13"]
+      fail-fast: true
+    steps:
+      - name: Checkout rms-pdsfile
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Run all checks
+        # run-all-checks.sh looks for the venv at ./venv and activates it itself.
+        # Sequential mode streams each gate's output straight to the job log.
+        run: |
+          rm -rf venv
+          python -m venv venv
+          source venv/bin/activate
+          python -m pip install --upgrade pip
+          python -m pip install wheel
+          python -m pip install -e ".[dev]"
+          echo
+          python -m pip freeze
+          echo
+          scripts/run-all-checks.sh --sequential
+
   test:
     name: Test pdsfile
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,6 +27,10 @@ jobs:
     # data.
     name: Lint and holdings-free tests
     runs-on: ubuntu-latest
+    # This job runs code from the pull-request head on a hosted runner, so it
+    # gets no more than it needs to read the tree.
+    permissions:
+      contents: read
     strategy:
       matrix:
         python-version: ["3.10", "3.13"]
@@ -36,6 +40,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          # Nothing here pushes; leaving the token in .git/config would only
+          # expose it to the PR-authored code this job runs.
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5

--- a/critiques/deferred-observations.md
+++ b/critiques/deferred-observations.md
@@ -184,7 +184,7 @@ Two further observations, not defects in a single tool:
    fix works, and its cost is prohibitive on the gate that would pay it. Measured
    on the limited holdings copy with
 
-   ```
+   ```sh
    PDSFILE_TEST_HOLDINGS=full python -m coverage run -m pytest \
        tests/holdings_maintenance/test_pds3_archives.py --mode ns -q -p no:cacheprovider
    ```
@@ -429,3 +429,19 @@ Two further observations, not defects in a single tool:
     in a frozen file is freeze-neutral but needs owner sign-off, exactly like the
     dead-`noqa` item recorded under "From PR-03+04" above. **Owner:** the same
     owner-blessed touch-up of the frozen files.
+
+### Added by the CodeRabbit review of PR #107 (2026-07-26)
+
+22. **The self-hosted `test` job still runs on default workflow permissions.**
+    `zizmor` flags `excessive-permissions` on `.github/workflows/run-tests.yml`:
+    neither the workflow nor the `test` job declares a `permissions:` block, so
+    both `pull_request` jobs got the repository's default token scope. PR-14
+    fixed the half it owns — the new `lint` job declares
+    `permissions: contents: read` and its checkout sets
+    `persist-credentials: false` — but the PR-14 bullet says to keep the
+    self-hosted matrix exactly as it is, so the `test` job was left alone. It
+    checks out PR-head code and then runs it, and it additionally needs whatever
+    scope `codecov/codecov-action` uses, so the right block is not simply a copy
+    of the lint job's. The same applies to `run-tests-and-opus.yml`, which is
+    likewise untouched here. **Owner:** a CI-hardening pass, or PR-37's
+    finalization sweep.

--- a/critiques/deferred-observations.md
+++ b/critiques/deferred-observations.md
@@ -178,12 +178,54 @@ Two further observations, not defects in a single tool:
    from the 100+ new tests. Subprocess invocation is load-bearing and cannot be
    given up (see §2.2 of `plans/2026-07-25-pr-13-subplan.md`), so the fix is a
    `COVERAGE_PROCESS_START` / `sitecustomize` hook in the tests' subprocess
-   environment. **Owner: PR-14**, which owns CI/coverage correspondence.
-9. **`tests/api/test_api_freeze.py` is not marked `holdings_free`.** PR-14's spec
-   says the hosted no-holdings job must run the API-freeze test as part of its
-   pytest subset, but the collect-and-skip rule will still skip it there. PR-13
-   only owed the `crlf` tests. **Owner: PR-14** — mark the API-freeze test (and
-   any other genuinely holdings-free test) when that job is built.
+   environment. ~~**Owner: PR-14**, which owns CI/coverage correspondence.~~
+
+   **STILL DEFERRED — re-assigned by PR-14 (2026-07-26), with measurements.** The
+   fix works, and its cost is prohibitive on the gate that would pay it. Measured
+   on the limited holdings copy with
+
+   ```
+   PDSFILE_TEST_HOLDINGS=full python -m coverage run -m pytest \
+       tests/holdings_maintenance/test_pds3_archives.py --mode ns -q -p no:cacheprovider
+   ```
+
+   the only variable being whether
+   `tests/holdings_maintenance/support.py::run_tool` prefixes each tool
+   subprocess with `-m coverage run --parallel-mode --rcfile <repo>/pyproject.toml`
+   and sets an absolute `COVERAGE_FILE` in the subprocess environment:
+
+   | tool subprocesses | pytest summary line |
+   |---|---|
+   | uninstrumented (today) | `8 passed, 5 warnings in 16.06s` |
+   | instrumented | `8 passed, 5 warnings in 138.84s` |
+
+   An **8.6x** slowdown, on the arm of the self-hosted suite that runs on every PR
+   and nightly across four Python versions. The cost is the line tracer running
+   inside each tool, so the `sitecustomize` / `COVERAGE_PROCESS_START` route named
+   above measures the same and costs the same. It also requires parallel data
+   files plus a `coverage combine` step (guarded, because a holdings root that
+   lacks a declared source subset legitimately produces zero child data files) in
+   `scripts/automated_tests/pdsfile_main_test.sh` — the data-gate driver.
+
+   Two things make waiting cheap: coverage numbers stay informational until the
+   targets are set, and PR-28 converts the `shelf_consistency_check` and
+   `show_opus_products` tests to in-process `main()` calls, which are measured
+   with no subprocess machinery at all. If it is taken up, `COVERAGE_CORE=sysmon`
+   (Python 3.12+) is the lever worth measuring first — and note the coverage
+   artifact is uploaded from the 3.13 leg only, so the instrumentation need not be
+   paid on every leg. **Owner: PR-37** (Phase 8, "set codecov targets"), which is
+   where the number first has to mean something.
+9. ~~**`tests/api/test_api_freeze.py` is not marked `holdings_free`.**~~
+   **RESOLVED (PR-14).** `tests/api/conftest.py` marks every item collected from
+   `tests/api/` `holdings_free`, so the freeze test runs in the hosted
+   no-holdings job (`tests/api/test_api_freeze.py` itself is frozen by §6.4 and is
+   not edited). The directory-wide form also covers later additions such as
+   `tests/api/test_mixin_collisions.py` (PR-17).
+
+   The entry's second half — "and any other genuinely holdings-free test" — was
+   surveyed by measurement, not by inspection, and deliberately left unmarked;
+   the reasoning and the numbers are in §4 of `critiques/pr-14/validation.md`
+   and the residual option is recorded as entry 15 below.
 
 ### Added by the PR-13 adversarial review (round 2)
 
@@ -231,8 +273,22 @@ Two further observations, not defects in a single tool:
     direction (not decided here): give the option `choices=('s', 'ns')` plus an
     explicit `default`, so a typo fails loudly and the default is a mode the suite
     actually exercises — or document what the mixed combination is for and cover
-    it. **Owner: PR-14**, which owns CI / `run-all-checks.sh` pytest-invocation
-    correspondence.
+    it. ~~**Owner: PR-14**, which owns CI / `run-all-checks.sh` pytest-invocation
+    correspondence.~~
+
+    **RESOLVED (PR-14, owner decision 2026-07-26).** `--mode` now carries
+    `choices=('s', 'ns')` and `default='ns'`, so a mistyped mode is a usage error
+    and a bare `pytest` selects the broader of the two validated modes (`ns` is
+    the only mode in which the whole tree passes; the shelves-only pass is
+    pds3-only for that reason). The mixed `else` branch is deleted rather than
+    left unreachable: `setup` now derives one `shelves_only` boolean and applies
+    it to both classes, so a session where `Pds3File` and `Pds4File` disagree can
+    no longer be constructed. `scripts/run-all-checks.sh` passes `--mode ns`
+    explicitly so its invocation does not depend on the default. Every `--mode`
+    invocation in the repo was surveyed; all already passed an explicit `s` or
+    `ns`, so no existing invocation changes behavior, and the two full-data
+    per-test pass/fail sets are byte-identical to the pre-change runs
+    (`critiques/pr-14/validation.md`).
 13. **The maintenance-tool tests run in the `--mode ns` invocation only.**
     `scripts/automated_tests/pdsfile_main_test.sh` adds
     `tests/holdings_maintenance/` to the not-shelves-only pass and deliberately
@@ -250,6 +306,14 @@ Two further observations, not defects in a single tool:
     PR-28** (re-derive for the two tools it converts), with **PR-14** noting the
     same coupling if it changes how the suite is invoked. Entry 12 above is the
     related question of what mode a `--mode`-less run selects at all.
+
+    **PR-14 note (2026-07-26).** PR-14 leaves
+    `scripts/automated_tests/pdsfile_main_test.sh` untouched, so the two-pass
+    split and its `--mode ns`-only tool-test placement are unchanged. It does add
+    a third invocation, `scripts/run-all-checks.sh`, which runs the whole
+    `tests/` tree — including `tests/holdings_maintenance/` — once, under
+    `--mode ns`. That is the same mode the tool tests already ran in, so the
+    coupling recorded here is unchanged and PR-28 still owns re-deriving it.
 
 ### Added by the CI failure of PR #105 (2026-07-26)
 
@@ -276,3 +340,92 @@ Two further observations, not defects in a single tool:
     determine — those from rules whose glob matched a single path — are pinned in
     exact order, so a rule reordering its messages still fails the test. When the
     tool starts sorting, the test keeps passing and the golden stays valid.
+
+### Added by the PR-14 adversarial review (round 1)
+
+15. **~291 data-suite tests pass with no holdings present, and are deliberately
+    not marked `holdings_free`.** Measured on PR-14's branch by lifting the
+    blanket skip with a throwaway `tryfirst` plugin that marks every collected
+    item `holdings_free`, with all four holdings env vars unset:
+    **315 passed / 387 failed / 122 skipped** — i.e. 291 beyond the 24 the
+    hosted job runs today. Grouped by test *function*: 124 functions have every
+    parametrized case passing, 41 are **mixed** (some cases pass, some fail) and
+    126 fail outright. The four modules involved are
+    `tests/pds{3,4}file/test_pds{3,4}file_blackbox.py`,
+    `test_pds3file_blackbox_cached.py` and `test_pds3file_whitebox.py`. The
+    result is not order-dependent: each module run alone yields the same passing
+    set as it does inside the whole-tree run.
+
+    PR-14 did not mark them, for four reasons recorded in §4 of
+    `critiques/pr-14/validation.md`: they do not build their own inputs (they
+    concatenate the *resolved* holdings root, which with no holdings is PR-09's
+    synthetic `/pdsfile-no-holdings/...` placeholder — the test ids contain it,
+    so they assert against a root that does not exist); the pass/fail split runs
+    through the middle of parametrize tables, not along module, class or function
+    lines, so 41 functions cannot be marked at all; nothing pins the
+    no-filesystem-access property, so a mark is a CI-only tripwire right before
+    Phase 5 rewrites those very code paths; and the plan's own enumeration of the
+    subset (§1 G3: "API freeze, tool unit tests, import/collection smoke") does
+    not include the data suite.
+
+    Worth revisiting only together with **issue #92** (move inline
+    `@parametrize` values into golden files), which is where the tables would be
+    split into a data-dependent and a path-only half in the first place. #92 is
+    listed in §9 of the plan as future work outside this effort. **Owner: #92 /
+    post-merge.**
+16. **`run_tests_coverage.sh` at the repo root cannot run.** It invokes
+    `pytest pdsfile/pds3file/tests/ pdsfile/pds3file/rules/*.py`, paths that
+    stopped existing when PR-05 moved the package under `src/` and PR-07 moved
+    the tests to the top-level `tests/` tree. It is one of the `--mode` call
+    sites PR-14 surveyed (it passes valid modes, so PR-14's `choices` change does
+    not affect it) and was otherwise left alone. Delete it or update it to the
+    current layout. **Owner:** whichever PR next touches the root scripts;
+    PR-37's finalization sweep at the latest.
+17. **`CONTRIBUTING.md` documents `pytest` without holdings or `--mode`.** Its
+    testing section shows bare `pytest` / `pytest tests/<file>` with no mention
+    of `PDS3_HOLDINGS_DIR`/`PDS4_HOLDINGS_DIR`, `PDSFILE_TEST_HOLDINGS`, or
+    `--mode`. Now that the pytest gate is enabled, a contributor following it
+    gets an 800-skip run with no explanation of why. **Owner: Phase 7**
+    (PR-33 ch. 5 "Test-suite guide", or PR-34 with the README rewrite).
+18. **`tests/pds{3,4}file/helper.py` resolve holdings at import time.** Each
+    module does `PDS3_HOLDINGS_DIR = resolve_holdings().pds3_root` at import,
+    rather than reading the session's `config._pdsfile_holdings`. The two agree
+    today because the resolver is a pure function of the environment and nothing
+    mutates it mid-session, but they are two independent resolutions of the same
+    question. **Owner:** whichever PR restructures `tests/pds{3,4}file/` (the
+    same one that owns PR-07's `helper.py` double-import note above).
+
+### Added by the PR-14 adversarial review (round 2)
+
+19. **`[tool.pytest.ini_options]` declares no `testpaths`.** `python_testing.mdc`
+    asks for it, and `critiques/deferred-observations.md`'s PR-08 entry already
+    notes that "whichever PR adds `testpaths`" also owns PR-07's `helper.py`
+    double-import. Harmless today — every invocation names its paths explicitly,
+    and `venv/` is in pytest's default `norecursedirs` — so it is a tidiness item,
+    not a correctness one. Pre-existing since PR-03. **Owner:** the same PR that
+    restructures `tests/pds{3,4}file/` (see the PR-08 entry above).
+
+### Added by the PR-14 adversarial review (round 3)
+
+20. **The hosted no-holdings job has no floor on how many tests actually ran.**
+    The plan calls that run "itself the regression test for PR-09's graceful
+    skip", and it does catch the primary regression: a collection error exits
+    non-zero. But a regression that skipped *everything* — say the
+    `tests/api/conftest.py` path predicate quietly stopping matching — exits 0 and
+    the job stays green, because "0 passed, 824 skipped" is a passing pytest run.
+    PR-14 hardened the one known way that could happen (both sides of the path
+    comparison are resolved), and each PR's §6.2 record pins the expected
+    no-holdings counts, so a drop is visible in review — but nothing fails
+    automatically. A cheap tripwire (assert a floor on the passed count, or
+    require specific node ids to have run) belongs with whatever PR next touches
+    the hosted job. **Owner:** PR-37's finalization sweep, or any earlier PR that
+    edits the lint job.
+21. **Two §6.4-frozen files cite the archived v1 plan.**
+    `scripts/dump_public_api.py` and `tests/api/test_api_freeze.py` both point at
+    `plans/2026-07-17-modernization-plan.md`, which moved to `plans/archive/`.
+    Both files are under the absolute prohibition on editing, so PR-14 left them
+    alone (it did fix the same stale reference in
+    `.cursor/rules/pdsfile_overrides.mdc`, which is not frozen). Fixing a comment
+    in a frozen file is freeze-neutral but needs owner sign-off, exactly like the
+    dead-`noqa` item recorded under "From PR-03+04" above. **Owner:** the same
+    owner-blessed touch-up of the frozen files.

--- a/critiques/pr-14/round-1.md
+++ b/critiques/pr-14/round-1.md
@@ -1,0 +1,133 @@
+# PR-14 — adversarial review round 1
+
+**Date:** 2026-07-26
+**Reviewer:** fresh opus-class subagent, no development context, no prior rounds.
+**Input:** the PR-14 section + Phase-4 preamble + §2 + §6.1/§6.2/§6.4/§6.6 of
+`plans/2026-07-25-modernization-plan.md`, the two relayed owner decisions
+(#102 → drop the classifier; `--mode` → `default='ns'` + `choices`), the exact
+`git diff origin/rewrite...HEAD`, and read access to the repo at HEAD.
+**Verdict:** `goal not met` (1 Major, 5 Minor, 4 Deferred).
+
+## Major
+
+### M1 — Deferred entry 9 was closed on a survey conclusion that is false
+
+The records claimed "the survey for other genuinely holdings-free tests found
+none: everything else under `tests/` either instantiates a `PdsFile` against a
+holdings root or needs the copied tool tree". The reviewer showed that
+`from_abspath` / `from_logical_path` only parse a path — they do not stat — and
+measured **291 tests outside `tests/api/` passing with no holdings** once the
+blanket skip is lifted. The PR-14 bullet names "any other no-data tests", so the
+claim is both in scope and hollow.
+
+**Disposition: the false claim is FIXED; the demand to mark them is REBUTTED.**
+
+*Fixed.* The reviewer is right that the stated reason was wrong, and the
+measurement was reproduced independently: `315 passed / 387 failed /
+122 skipped` with a throwaway `tryfirst` plugin marking everything
+`holdings_free` and all four holdings env vars unset. Per function: 124
+all-cases-pass, 41 mixed, 126 all-fail. Not order-dependent (each module alone
+yields the same passing set as inside the whole-tree run). §4 of
+`critiques/pr-14/validation.md` now carries the measurement instead of the
+inspection claim, and the entry-9 note in `critiques/deferred-observations.md`
+no longer asserts an empty search.
+
+*Rebutted.* Marking them is not the right answer, for reasons the measurement
+itself supplies:
+
+1. They fail the marker's own registered definition ("test builds its own inputs
+   and needs no holdings tree"). They concatenate the **resolved** holdings root,
+   which with no holdings is PR-09's synthetic placeholder — visible in the test
+   ids, e.g.
+   `test_logical_path_from_abspath[/pdsfile-no-holdings/pdsdata/holdings/volumes/...]`.
+   Passing against a root that does not exist is a different property from
+   needing no root.
+2. There is no boundary to mark along: 41 functions are **mixed** at the
+   parametrized-case level, so the split runs through the middle of the inline
+   `@parametrize` tables. Splitting those is issue **#92**, which §9 of the plan
+   lists as future work outside this effort. The reviewer concedes this point
+   ("the fix is not trivially 'mark the modules'").
+3. Nothing pins the no-filesystem-access property, so a mark is a hosted-CI-only
+   tripwire — the failure class that cost PR-13 three CI-only failures — placed
+   immediately before Phase 5 rewrites those very paths (PR-15 bug 3 changes the
+   holdings-env lookup in `abspath_for_logical_path`; PR-16 moves
+   `logical_path_from_abspath`, `repair_case`, `selected_path_from_path`).
+4. §1 G3 enumerates the subset as "API freeze, tool unit tests,
+   import/collection smoke". The Phase-4 bullet's "any other no-data tests" reads
+   against that enumeration; the blackbox/whitebox suites are the data suite.
+
+The reviewer's own supporting observations argue the same way: some of the passes
+are tautological (`test__info` asserts `res1 == res2`;
+`test_logical_path_from_abspath` swallows `ValueError` into `assert True`).
+
+The option is preserved rather than dropped: **entry 15** in
+`critiques/deferred-observations.md` records the numbers, the four reasons, and
+assigns it to issue #92 / post-merge.
+
+## Minor
+
+### m2 — The PR rewrote owner-locked deviation (7) on one run's evidence
+
+Valid. **Fixed by removing the cause rather than the record.** Deviation (7) is
+reverted to its original wording, and `scripts/run-all-checks.sh` now defaults
+`PYTEST_WORKERS` to **1 (serial)** instead of `auto`, so enabling the gate does
+not quietly make full-data runs parallel. This also matches the plan's retirement
+of PR-12 ("xdist … adds shared-state risk") and removes the unmeasured memory bet
+the reviewer flagged (one preload measured at 105 MB peak RSS against the limited
+copy; `-n auto` on a 30-core machine means 30 of them). `-w auto` remains
+available and its measured equivalence (33.9 s vs 142.1 s, identical pass/skip
+set) is recorded in `critiques/pr-14/validation.md` §3. Re-validated after the
+change: with holdings 790/34 in 3 m 15 s; without holdings 24/800 in 21 s. No
+plan addendum is needed, because no rule is now being deviated from.
+
+### m3 — Round records referenced but absent
+
+Valid and expected — this file is the first one. `round-<k>.md` files are
+committed as each round completes, before the PR is opened.
+
+### m4 — The nightly-alerting deliverable was unrecorded
+
+Valid. §9 of `critiques/pr-14/validation.md` now states that settled decision
+§8.7 (GitHub built-in notifications) stands, that this is a no-work deliverable,
+and that the cron and its notification behavior are unchanged. The branch-
+protection deliverable (§8.8) is recorded alongside it.
+
+### m5 — The entry-8 re-deferral rested on an unreproducible measurement
+
+Valid. Both `critiques/pr-14/validation.md` §7 and entry 8 of
+`critiques/deferred-observations.md` now carry the exact command line, the exact
+one-line code change that is the only variable, and the verbatim pytest summary
+lines (`8 passed, 5 warnings in 16.06s` vs `8 passed, 5 warnings in 138.84s`).
+
+### m6 — The new comments re-list the gate set the script is meant to own
+
+Valid — enumerating the gates in a comment is the hand-maintained parity
+`environment.mdc` exists to avoid, and it goes stale at PR-23/24 and PR-31. Both
+the workflow comment and deviation (8) now point at the script instead of listing
+its contents.
+
+## Deferred (appended to `critiques/deferred-observations.md`)
+
+| # | Item | Owner |
+|---|---|---|
+| 15 | ~291 data-suite tests pass with no holdings; measurement + why they are not marked | issue #92 / post-merge |
+| 16 | `run_tests_coverage.sh` uses pre-`src/`-layout paths and cannot run | next root-scripts PR / PR-37 |
+| 17 | `CONTRIBUTING.md` documents `pytest` with no holdings env vars or `--mode` | Phase 7 (PR-33/PR-34) |
+| 18 | `tests/pds{3,4}file/helper.py` resolve holdings at import time, not from the session config | the `tests/pds{3,4}file/` restructure PR |
+
+The reviewer also flagged the stale `plans/2026-07-17-modernization-plan.md`
+reference at `.cursor/rules/pdsfile_overrides.mdc:12`. That file is already being
+edited by this PR and the fix is a one-word path change, so it was fixed here
+rather than deferred: it now points at the active v2 plan.
+
+## Confirmed satisfied by the reviewer
+
+Workflow YAML parses and the diff to `run-tests.yml` is additions only (the
+self-hosted matrix, its triggers and the codecov step byte-identical);
+`run-tests-and-opus.yml` untouched; the exact CI command passes with no holdings;
+the freeze marker works in both invocations, including `--strict-markers` under
+`--confcutdir=tests/api`; the no-holdings before/after independently reproduced
+as exactly one added passing test; freeze artifacts untouched; ruff ratchet not
+widened; `--mode` hardening behavior-preserving with every call site surveyed;
+full-data evidence present, non-stale (nothing under `src/pdsfile/`) and matching
+the PR-13 baseline; no absolute holdings path anywhere; commit hygiene clean.

--- a/critiques/pr-14/round-2.md
+++ b/critiques/pr-14/round-2.md
@@ -1,0 +1,110 @@
+# PR-14 — adversarial review round 2
+
+**Date:** 2026-07-26
+**Reviewer:** a second fresh opus-class subagent, no development context, no
+knowledge of round 1.
+**Input:** identical framing to round 1, against the updated
+`git diff origin/rewrite...HEAD`.
+**Verdict:** `goal not met` (1 Major, 6 Minor, 4 Deferred).
+
+The reviewer independently reproduced the baseline (a worktree at
+`origin/rewrite`), the no-holdings before/after, both freeze invocations, the
+`--mode NS` usage error, the ratchet, the untouched self-hosted job, and the
+confidentiality check — all confirmed. It additionally probed two stock-runner
+hazards this executor had not: pyroma under a tagless/shallow
+`setuptools_scm` version (exit 0, still 10/10) and the clean-install gate with no
+holdings env vars set (passes — a condition it had never run in before).
+
+## Major
+
+### M1 — The newly-enabled pytest gate passes vacuously on a data machine
+
+Valid, and the most important finding of the loop. §3.4 tells the operator to
+export `PDS3_HOLDINGS_DIR` / `PDS4_HOLDINGS_DIR` and nothing more, but
+`tests/support/holdings.py::resolve_holdings` only consults those two when
+`PDSFILE_TEST_HOLDINGS=full`. So the exact environment §3.4 describes produced
+**24 passed / 800 skipped** and a green `✓ SUCCESS` — 3% of the suite, reported
+as a pass — which contradicts the deliverable's own wording ("with holdings env
+vars it runs the full suite"). The failure mode did not exist before this PR
+(`ENABLE_PYTEST=false`), and §2 requires a local full-data run after every
+Phase 5/6 PR, which is next.
+
+**Fixed.** `scripts/run-all-checks.sh` now selects `PDSFILE_TEST_HOLDINGS=full`
+for its own invocation when both roots are exported and no selector is set, and
+prints which run it is doing in every case. An explicit selector still wins;
+`PDSFILE_TEST_DATA_DIR` is never set, so the mini flavor stays dormant (ground
+rule 3); `tests/support/holdings.py` is untouched — the script uses PR-09's
+selector exactly as `scripts/automated_tests/pdsfile_main_test.sh` already does.
+The holdings variables are now documented in the script's `# Environment:`
+header, so `--help` says so too.
+
+Verified across all three environments (§3a of `critiques/pr-14/validation.md`):
+both-roots-no-selector → `holdings: full`, 790/34; explicit selector →
+`holdings: full`, 790/34; nothing set → `no holdings: holdings-free subset only`,
+24/800.
+
+## Minor
+
+### m1 — The script runs `tests/`; the data driver runs a hand-maintained path list
+
+**Rebutted.** The drift is real but predates this PR, and closing it means
+editing `scripts/automated_tests/pdsfile_main_test.sh`, which the PR-14 bullet
+explicitly forbids ("Keep the self-hosted full-data matrix exactly as it is") —
+the reviewer offered this rebuttal itself. It is also the direction that matters
+least: the whole-tree invocation this PR adds is precisely what would *catch* a
+new top-level test directory the driver's list missed, and it now runs on every
+PR (hosted, no holdings) and locally with holdings. Recorded here rather than
+acted on.
+
+### m2 — The plan's gate table and enabled-set line went stale
+
+Valid and in scope: PR-14 is the PR that flips those gates, and the table's
+`**Active** (PR-xx)` pattern shows it is maintained as gates land. Fixed —
+`plans/2026-07-25-modernization-plan.md` now marks the hosted lint job
+`**Active** (PR-14)` and lists pytest in the enabled set.
+
+### m3 — `tests/api/conftest.py` marks a whole directory on a comment-only invariant
+
+Partly valid. **Rebutted on the mechanism, fixed on the wording.** The suggested
+alternative — per-module `pytestmark` — cannot be applied to the one module that
+matters, because §6.4 forbids editing `tests/api/test_api_freeze.py`. And the
+failure mode of the directory rule is the good one: a future test in
+`tests/api/` that does need holdings **fails loudly on the first no-holdings
+run** rather than silently skipping. The conftest now states that as a rule of
+the directory, with the consequence spelled out.
+
+### m4 — `item.path` compared unresolved
+
+Valid, and the failure mode is the bad kind: through a symlinked checkout the
+comparison would quietly stop matching and the freeze test would go back to
+skipping on the hosted runner — lost coverage, not a red build. **Fixed:** both
+sides are resolved.
+
+### m5 — A commit message asserts something the final tree contradicts
+
+Valid. Commit `626892a` described a change to deviation (7) that round 1 then
+reverted. **Fixed:** the branch was re-committed from `origin/rewrite` so every
+message describes the tree that is actually being proposed.
+
+### m6 — The script header's "Code:" list omitted the clean-install gate
+
+Valid, pre-existing, one word. **Fixed.**
+
+## Deferred
+
+| # | Item | Owner |
+|---|---|---|
+| 19 | `[tool.pytest.ini_options]` declares no `testpaths` (pre-existing, PR-03) | the `tests/pds{3,4}file/` restructure PR |
+
+The reviewer also noted that the self-hosted leg runs neither `ruff` nor `pyroma`
+nor a standalone api-freeze invocation, so "exact correspondence" holds at the
+workflow level (the union of the two jobs) rather than per job. That is what the
+PR-14 bullet asks for and is recorded in §8 of the validation file. It agreed the
+"first proof comes from CI" statement is honest rather than hand-waving, and
+re-confirmed the disposition of entries 8, 9, 12 and 13, including that nothing
+of entry 8 is half-landed (`tests/holdings_maintenance/support.py` is not in the
+diff).
+
+On the round-1 rebuttal about the 291 unmarked data-suite tests, the reviewer
+called reason 1 the weakest of the four and reasons 2 and 3 decisive. Noted; the
+reasons are left as recorded, since the rebuttal does not rest on reason 1.

--- a/critiques/pr-14/round-3.md
+++ b/critiques/pr-14/round-3.md
@@ -26,7 +26,7 @@ same silent 3% run the guard was added to eliminate. **Fixed:** the guard now
 fires when **either** root is present, so a half-configured environment reaches
 `_resolve_full` and fails the session by name. Verified:
 
-```
+```text
 Running pytest (-n 1; holdings selection is invalid, pytest will report it)...
 ERROR: PDSFILE_TEST_HOLDINGS=full requires PDS4_HOLDINGS_DIR to be set
 ✗ Pytest failed   ✗ FAILURE - 1 check(s) failed

--- a/critiques/pr-14/round-3.md
+++ b/critiques/pr-14/round-3.md
@@ -1,0 +1,94 @@
+# PR-14 — adversarial review round 3
+
+**Date:** 2026-07-26
+**Reviewer:** a third fresh opus-class subagent, no development context, no
+knowledge of rounds 1-2.
+**Input:** identical framing, against the updated
+`git diff origin/rewrite...HEAD`.
+**Verdict:** `goal met` — **zero Major**, 6 Minor, 6 Deferred.
+
+The reviewer independently re-derived the baseline and the no-holdings
+before/after, ran both freeze invocations (including under `-n 1 --dist
+loadscope`), re-checked the ratchet, the untouched self-hosted job and
+`run-tests-and-opus.yml`, confirmed confidentiality, and spot-checked the
+full-data figures against JUnit artifacts on disk (`tests="824" skipped="34"`
+and `tests="558" skipped="3"` → 790/34 and 555/3, matching PR-13's baseline).
+It confirmed every PR-14 bullet delivered and entries 8/9/12/13 correctly
+disposed, with nothing of entry 8 half-landed.
+
+## Minor
+
+### m1 — The anti-vacuous-pass guard only fired when *both* roots were exported
+
+Valid, and the counterexample was reproduced: one root exported and the other
+missing gave `no holdings: holdings-free subset only`, 24/800, `✓ SUCCESS` — the
+same silent 3% run the guard was added to eliminate. **Fixed:** the guard now
+fires when **either** root is present, so a half-configured environment reaches
+`_resolve_full` and fails the session by name. Verified:
+
+```
+Running pytest (-n 1; holdings selection is invalid, pytest will report it)...
+ERROR: PDSFILE_TEST_HOLDINGS=full requires PDS4_HOLDINGS_DIR to be set
+✗ Pytest failed   ✗ FAILURE - 1 check(s) failed
+```
+
+### m2 — The shell guard re-derived the resolver's policy and could print a wrong answer
+
+Valid: the shell never consulted `PDSFILE_TEST_DATA_DIR`, so with the dormant
+mini flavor resolvable the script would have printed "no holdings" while the
+session ran `mini`. **Fixed:** the script now asks `resolve_holdings()` for the
+flavor and prints that, so the log cannot disagree with the session. The shell
+retains only the script-local *policy* (a root present and no selector ⇒ full),
+not a second copy of the resolution. Verified against the dormant path:
+resolver `mini` → script prints `holdings: mini`.
+
+### m3 — A comment in `run-all-checks.sh` carried a rationale this PR itself falsifies
+
+Valid: it said `--confcutdir=tests/api` exists because `tests/conftest.py`
+"requires holdings env vars to import", untrue since PR-09. **Fixed:** the
+comment now gives the real reason (no session options, no holdings resolution, no
+preload), matching the one in `tests/api/conftest.py`.
+
+### m4 — The hosted job has no floor on how many tests actually ran
+
+Valid observation, **rebutted as out of scope and deferred.** It asks for a new
+enforcement mechanism no PR-14 bullet requests. The specific regression it
+imagines — the path predicate silently ceasing to match — is the one round 2
+already hardened (both sides of the comparison resolved), and each PR's §6.2
+record pins the expected no-holdings counts, so a drop is visible at review.
+Recorded as **entry 20** of `critiques/deferred-observations.md`, owned by
+PR-37 or any earlier PR that edits the lint job.
+
+### m5 — The script does not reproduce CI, because CI also runs a `--mode s` pass
+
+Valid and worth recording; **fixed by documenting, not by changing the runs.**
+Adding a second pass to the script is not available: the self-hosted `s` pass is
+pds3-only, and a whole-tree `--mode s` run has five pre-existing pds4 failures
+(recorded under "From PR-08" in `critiques/deferred-observations.md`), so the
+script cannot simply run `--mode s tests`. And editing the data driver is
+forbidden by the PR-14 bullet. The asymmetry is now stated in the script's
+`# Environment:` header, at the pytest gate, in deviation (8), and in §8 of
+`critiques/pr-14/validation.md`.
+
+### m6 — Dropping the Windows classifier while keeping macOS, on a rationale that fits both
+
+Valid: the commit said the classifier "claimed support that is not tested",
+which condemns macOS equally. The real criterion is support, not CI coverage.
+**Fixed:** the commit message and deviation (8) now say the package is *not
+supported* on Windows, and §8a of the validation file records that macOS is a
+supported platform whose matrix entries are commented out rather than deleted,
+so it keeps its classifier deliberately.
+
+## Deferred
+
+| # | Item | Owner |
+|---|---|---|
+| 20 | The hosted job stays green if a regression skips everything | PR-37 or the next PR editing the lint job |
+| 21 | `scripts/dump_public_api.py` and `tests/api/test_api_freeze.py` cite the archived v1 plan; both are §6.4-frozen | owner-blessed touch-up of the frozen files |
+
+The reviewer re-raised, as already-recorded deferred items, entries 16-19 from
+earlier rounds, and noted that §3.4 prerequisite 3
+(`critiques/baselines/consumer-smoke-baseline.md`) is still missing and due
+before Phase 5. That is a coordinator/operator task explicitly outside PR-14 —
+it is being captured on a separate branch — and is reported upward rather than
+actioned here.

--- a/critiques/pr-14/round-4.md
+++ b/critiques/pr-14/round-4.md
@@ -74,3 +74,34 @@ is satisfied, with the recorded figures matching PR-13's baseline.
 Round 4 returns zero Major and no new un-rebutted Minor. Per §6.6 the loop is
 converged and the PR may be opened. Rounds 1-3 are in `round-1.md`, `round-2.md`
 and `round-3.md`; gate evidence is in `validation.md`.
+
+## Addendum — CodeRabbit review of PR #107
+
+Four findings, after the §6.6 loop had converged. Two fixed, one fixed in the
+half this PR owns, one rebutted.
+
+1. **Least-privilege permissions on the `pull_request` jobs** (Major, `zizmor`
+   `excessive-permissions`). Valid. **Fixed for the job this PR authors:** the
+   `lint` job declares `permissions: contents: read` and its checkout sets
+   `persist-credentials: false` — it runs PR-head code on a hosted runner and
+   never pushes, so it should hold nothing more. The self-hosted `test` job is
+   deliberately not touched (the PR-14 bullet freezes it, and it needs whatever
+   scope `codecov/codecov-action` uses, so its block is not a copy of the lint
+   job's). Recorded as deferred **entry 22**.
+2. **Pin actions to full commit SHAs instead of major tags** (Major).
+   **Rebutted.** `.cursor/rules/environment.mdc:19` mandates the opposite in so
+   many words: "Pin action versions to a major tag (e.g. `actions/checkout@v6`)
+   to balance stability and security updates." That rule has been in force since
+   PR-04, the whole repo follows it consistently across all four workflows, and
+   §6.6 says the plan and the repo rules win over a reviewer's preference.
+   Adopting SHAs would also mean editing the frozen self-hosted job's action
+   references. Changing this convention is an owner decision about
+   `environment.mdc`, not something a PR re-decides in passing.
+3. **`MD040`: fenced blocks without a language identifier** (Minor). Valid.
+   **Fixed** in `critiques/pr-14/validation.md` (4), `round-3.md` (1) and
+   `critiques/deferred-observations.md` (1). The pymarkdown gate does not land
+   until PR-34, but the fix is free.
+4. **The plan's gate-table row for the hosted job omitted `pyroma`** (Minor).
+   Valid — the job runs the whole check driver. **Fixed**, and the row now says
+   it runs whatever `run-all-checks.sh` enables rather than re-listing gates that
+   can drift.

--- a/critiques/pr-14/round-4.md
+++ b/critiques/pr-14/round-4.md
@@ -1,0 +1,76 @@
+# PR-14 — adversarial review round 4 (scoped)
+
+**Date:** 2026-07-26
+**Reviewer:** a fourth fresh opus-class subagent, no development context, no
+knowledge of rounds 1-3.
+**Scope:** §6.6's fourth-round rule — "confirm the prior round's findings are
+resolved; raise only **new Major** findings". The reviewer was given the earlier
+findings as claims to disprove, not as a narrative, and was told to verify
+against the code rather than the records.
+**Verdict:** `goal met` — **zero Major**, all six claims confirmed resolved.
+
+## Part 1 — prior findings
+
+| # | Claim | Status |
+|---|---|---|
+| 1 | The pytest gate can no longer pass vacuously | **resolved** |
+| 2 | The API-freeze test runs with no holdings, without editing the frozen test | **resolved** |
+| 3 | `--mode` hardening is complete and behavior-preserving | **resolved** |
+| 4 | Deferred entry 8 is re-deferred, not half-landed | **resolved** |
+| 5 | No commit message asserts anything the tree contradicts | **resolved** |
+| 6 | The documentation-consistency fixes hold | **resolved** |
+
+The reviewer re-derived rather than read, in the cases that matter:
+
+- **(1)** It could not construct a green-but-vacuous environment. It confirmed
+  the guard fires on **either** root, that a one-root environment fails with
+  `ERROR: PDSFILE_TEST_HOLDINGS=full requires PDS4_HOLDINGS_DIR to be set`, and
+  that the printed flavor cannot disagree with the session because the script
+  calls `resolve_holdings()` in the same environment after the export. It probed
+  the selector-set, empty-selector, nonexistent-root and dormant-`mini` cases;
+  each lands on the branch the script prints.
+- **(2)** Confirmed with `--trace-config` that the `--confcutdir=tests/api`
+  invocation registers **only** `tests/api/conftest.py` (and rejects `--mode`,
+  which is what the new comment claims), and then re-ran the whole thing
+  **through a symlinked checkout** — still green, so the `resolve()` on both
+  sides of the path comparison is load-bearing and works.
+- **(3)** Re-enumerated every `--mode` call site and confirmed one consumer of
+  `option.mode` repo-wide.
+- **(4)** Confirmed no file under `tests/holdings_maintenance/` is in the diff
+  and that `run_tool` is the plain form.
+
+Corroborating checks it ran unprompted: frozen artifacts, `tests/golden/`,
+`scripts/automated_tests/` and `run-tests-and-opus.yml` all absent from the diff;
+ruff clean and the ratchet untouched; pyroma 10/10; no absolute holdings path;
+`run-all-checks.sh` still mode `100755`; the new conftest is LF and covered by
+`*.py text eol=lf`; and — for the full-data gate, without re-running it — that
+`git diff --name-only origin/rewrite -- src/` is empty, so §6.6's staleness rule
+is satisfied, with the recorded figures matching PR-13's baseline.
+
+## Part 2 — new Major findings
+
+**None.**
+
+## Noted (non-blocking), and what was done
+
+1. *The `# Environment:` header did not describe the either-root guard or the
+   one-root hard failure.* **Fixed** — the header now says so, so `--help` is
+   accurate.
+2. *`.cursor/rules/pdsfile_overrides.mdc` said the self-hosted matrix "covers the
+   two versions in between", understating it.* **Fixed** — it covers all four.
+3. *`2>/dev/null || echo 'unresolved'` collapses any probe failure into "holdings
+   selection is invalid".* Left as is. The scenario the note imagines — the probe
+   failing while pytest runs green — cannot occur: `tests/conftest.py` imports
+   `tests.support.holdings` at module level, so an import-time failure there is a
+   collection error and the gate fails. A resolver `RuntimeError`, the realistic
+   cause, is exactly what the message describes.
+4. *`PDSFILE_TEST_DATA_DIR` pointing at a directory without `holdings/` +
+   `pds4-holdings/` still yields a silent holdings-free green.* Left as is: those
+   are PR-09's semantics on the dormant mini path, which ground rule 3 says to
+   leave exactly as merged, and nothing sets that variable.
+
+## Termination
+
+Round 4 returns zero Major and no new un-rebutted Minor. Per §6.6 the loop is
+converged and the PR may be opened. Rounds 1-3 are in `round-1.md`, `round-2.md`
+and `round-3.md`; gate evidence is in `validation.md`.

--- a/critiques/pr-14/topology.md
+++ b/critiques/pr-14/topology.md
@@ -1,0 +1,23 @@
+# PR-14 execution topology
+
+Recorded per plan §6.7 ("Record the chosen topology in `critiques/`").
+
+The four-level nesting is collapsed from the top, which §6.7 prescribes as the
+fallback ("collapse levels from the **top**, never the bottom"):
+
+| Level | Who |
+|---|---|
+| Top-level coordinator | the interactive session |
+| Phase-4 coordinator | the interactive session (same context) |
+| **PR-executor for PR-14** | a dedicated subagent — carries implementation + the §6.6 loop end to end |
+| §6.6 adversarial reviewer | one fresh, no-context opus-class subagent **per round**, spawned by the PR-executor |
+
+What is preserved: exactly one PR-executor subagent for this PR, and under it a
+new reviewer per round that receives no implementation conversation, no executor
+reasoning and no prior round records — only the PR-14 section of the plan, the
+Phase-4 preamble, §2, the relevant §6.1/§6.2/§6.6 rules including the
+progressive `.cursor/rules` compliance schedule, the exact
+`git diff origin/rewrite...HEAD`, and read access to the repo at HEAD.
+
+Rounds are recorded in `critiques/pr-14/round-<k>.md`; gate evidence is in
+`critiques/pr-14/validation.md`.

--- a/critiques/pr-14/validation.md
+++ b/critiques/pr-14/validation.md
@@ -1,0 +1,331 @@
+# PR-14 validation record
+
+**PR:** `ci: hosted lint/no-holdings job; keep self-hosted full-data gate`
+**Branch:** `pr-14-hosted-lint-ci`, based on `origin/rewrite` @ `0d588b3`
+(PR-13, "test: maintenance-tool test suite (#105)")
+**Date:** 2026-07-26
+
+## 0. Scope of the change (for the §6.6 staleness rule)
+
+**This PR touches no file under `src/pdsfile/`** (`git diff --name-only
+origin/rewrite -- src/` is empty). Per §6.6 step 5, the full-data records below
+therefore cannot go stale for any follow-up round that changes only
+`tests/`, CI, docs or records; they carry forward unless `src/` is touched.
+
+Files changed: `.github/workflows/run-tests.yml`, `scripts/run-all-checks.sh`,
+`tests/conftest.py`, `tests/api/conftest.py` (new), `pyproject.toml`,
+`.cursor/rules/pdsfile_overrides.mdc`, `critiques/`.
+
+## 1. Environment
+
+- Holdings resolved entirely from `PDS3_HOLDINGS_DIR` / `PDS4_HOLDINGS_DIR` with
+  `PDSFILE_TEST_HOLDINGS=full`. The roots used are the **limited testing copy the
+  goldens are tuned to**; its location is machine-local and appears in no
+  checked-in file (§3.4). No absolute holdings path appears in this record, in
+  the diff, or in the PR description.
+- Local interpreter: CPython 3.12 in the repo venv, `pip install -e ".[dev]"`.
+- Baselines compared against: the same two runs executed in a clean `git
+  worktree` at `origin/rewrite` (`0d588b3`) with the identical command lines,
+  captured in the same format and diffed line by line.
+
+## 2. Active §2 gates
+
+| Gate | Result |
+|---|---|
+| `ruff check src/pdsfile tests scripts` | **passed** — ratchet unchanged; the new `tests/api/conftest.py` needed no `per-file-ignores` entry |
+| pyroma | **10/10** (re-confirmed after the Windows trove classifier was dropped, issue #102) |
+| API-freeze | **passed** in both invocations: `pytest tests/api/test_api_freeze.py --confcutdir=tests/api` (hermetic) and as part of the whole-tree run |
+| Clean-install import check | **passed** (throwaway venv, `pip install .`, full module surface imports) |
+| Full-data suite, both modes | **per-test pass/fail set identical to `origin/rewrite`** — see §3 |
+| `scripts/run-all-checks.sh` end to end | **passed** with holdings (pytest 790/34) and without holdings (pytest 24/800) — see §3a for how the two are told apart |
+| Adversarial review loop | see `critiques/pr-14/round-<k>.md` |
+
+## 3. Full-data suite — must not change
+
+Command lines are exactly those in `scripts/automated_tests/pdsfile_main_test.sh`,
+run serially (the driver's own form), with `-rA` added so every outcome is
+recorded per test id.
+
+| Run | `origin/rewrite` @ `0d588b3` | this branch | diff |
+|---|---|---|---|
+| `--mode ns` (api, holdings_maintenance, pds3file, rules/pds3, pds4file, rules/pds4) | 790 passed / 34 skipped | **790 passed / 34 skipped** | **empty** |
+| `--mode s` (pds3file, rules/pds3) | 555 passed / 3 skipped | **555 passed / 3 skipped** | **empty** |
+
+The comparison is not a count check: the sorted `PASSED`/`SKIPPED`/`FAILED`
+lines of each run were diffed against the base worktree's, and both diffs are
+empty. This matches the baseline recorded by PR-13 (790/34 and 555/3), which
+superseded PR-09's 679/34.
+
+The script's own invocation covers the whole `tests/` tree in one pass
+(`pytest -q -n "$PYTEST_WORKERS" --dist loadscope tests --mode ns`) and also
+reproduces **790 passed / 34 skipped**. The gate's default worker count is
+**1 (serial)**, not `auto`: deviation (7) in
+`.cursor/rules/pdsfile_overrides.mdc` says full-data runs are serial, and the
+plan retired xdist adoption outright (PR-12, "adds shared-state risk"), so
+turning the gate on must not quietly make the data suite parallel. Each xdist
+worker runs the session fixture, i.e. its own full `Pds3File.preload` +
+`Pds4File.preload`; measured peak RSS for one preload against the limited copy is
+**105 MB**, and the complete set is larger, so `-n auto` on a many-core machine
+is a memory bet nobody asked for. `-w auto` remains available and was measured at
+33.9 s vs 142.1 s serial, with an identical pass/skip set — recorded here so the
+tradeoff is known, not so the default depends on it.
+
+## 3a. The gate must not pass vacuously
+
+The plan's wording is "with holdings env vars it runs the full suite; without,
+the holdings-free subset". That is not what the two roots alone produce:
+`tests/support/holdings.py::resolve_holdings` only reads
+`PDS3_HOLDINGS_DIR`/`PDS4_HOLDINGS_DIR` when `PDSFILE_TEST_HOLDINGS=full`, so a
+developer who followed §3.4 literally (export the two roots, nothing more) got
+**24 passed / 800 skipped** and a green `✓ SUCCESS` — 3% of the suite, reported
+as a pass. Reproduced before fixing.
+
+`scripts/run-all-checks.sh` now sets `PDSFILE_TEST_HOLDINGS=full` for its own
+invocation when **either** root is exported and no selector is set, and **prints
+what the resolver resolved** in every case. Either, not both: with only one root
+exported the resolver then fails the session and names the missing variable,
+which is the right outcome — half-configured is a mistake, not a
+3%-of-the-suite pass. An explicit `PDSFILE_TEST_HOLDINGS` always wins, and
+`PDSFILE_TEST_DATA_DIR` is never set, so the mini flavor stays dormant (ground
+rule 3). This uses PR-09's selector exactly as
+`scripts/automated_tests/pdsfile_main_test.sh` already does; it changes nothing
+in `tests/support/holdings.py`.
+
+The reported flavor comes from `resolve_holdings()` itself rather than from a
+second policy written in shell, so the log cannot disagree with the session. That
+matters for the dormant mini path: with `PDSFILE_TEST_DATA_DIR` pointing at real
+trees the resolver returns `mini`, and the script says `holdings: mini` — an
+inferred-in-shell message would have said "no holdings".
+
+Verified afterwards, on the same machine:
+
+| environment | script's pytest line | result |
+|---|---|---|
+| both roots exported, no selector | `holdings: full` | **790 passed / 34 skipped** |
+| `PDSFILE_TEST_HOLDINGS=full` + both roots | `holdings: full` | **790 passed / 34 skipped** |
+| one root only, no selector | `holdings selection is invalid, pytest will report it` | **fails**: `ERROR: PDSFILE_TEST_HOLDINGS=full requires PDS4_HOLDINGS_DIR to be set` |
+| `PDSFILE_TEST_DATA_DIR` set (dormant path) | `holdings: mini` | matches `resolve_holdings().flavor` |
+| no holdings env vars at all | `no holdings: holdings-free subset only` | **24 passed / 800 skipped** |
+
+## 4. No-holdings run — this is what changes
+
+Command: `pytest tests` with `PDS3_HOLDINGS_DIR`, `PDS4_HOLDINGS_DIR`,
+`PDSFILE_TEST_HOLDINGS` and `PDSFILE_TEST_DATA_DIR` all unset.
+
+| | `origin/rewrite` | this branch |
+|---|---|---|
+| passed | 23 | **24** |
+| skipped | 801 | **800** |
+| collected | 824 | **824** |
+| collection errors | 0 | **0** |
+
+`passed + skipped == collected` in both. The set difference of passing test ids
+is exactly one test, in one direction:
+
+```
++ PASSED tests/api/test_api_freeze.py::test_public_api_frozen
+```
+
+Nothing stopped passing. Justification: the freeze test regenerates the manifest
+in a clean child interpreter and compares it to the committed file — it reads no
+holdings at all (its own module docstring says so), and PR-13's addendum named it
+as the test PR-14 owed the marker to.
+
+**Survey for other holdings-free tests (deferred entry 9 asks for one).** This
+was measured, not eyeballed. The blanket skip was lifted with a throwaway
+`tryfirst` plugin marking every collected item `holdings_free`, and the whole
+tree was run with all four holdings env vars unset:
+
+```
+315 passed, 387 failed, 122 skipped
+```
+
+So **291 tests beyond the 24 the hosted job runs today do pass with no holdings
+present.** Grouped by test function: 124 functions have every parametrized case
+passing, **41 are mixed** (some cases pass, some fail), 126 fail outright. They
+live in four modules: `tests/pds3file/test_pds3file_blackbox.py`,
+`test_pds3file_blackbox_cached.py`, `test_pds3file_whitebox.py`, and
+`tests/pds4file/test_pds4file_blackbox.py`. The effect is not an artifact of
+ordering: each module run alone produces exactly the same passing set as it does
+inside the whole-tree run (134 / 43 / 46 / 68, zero differing lines).
+
+**They are still not marked `holdings_free`, deliberately.** Four reasons:
+
+1. **They do not satisfy the marker's definition.** `pyproject.toml` registers it
+   as "test builds its own inputs and needs no holdings tree". These build their
+   inputs by concatenating the *resolved* holdings root — which, with no
+   holdings, is PR-09's synthetic placeholder. The test ids say so out loud, e.g.
+   `test_logical_path_from_abspath[/pdsfile-no-holdings/pdsdata/holdings/volumes/...]`.
+   They pass against a root that does not exist, which is not the same property
+   as needing no root.
+2. **There is no boundary to mark along.** 41 functions are mixed at the
+   parametrized-case level, so the split runs through the middle of the inline
+   `@parametrize` tables, not along module, class or function lines. Splitting
+   those tables is issue **#92**, listed in §9 of the plan as future work outside
+   this effort.
+3. **Nothing pins the property, and Phase 5 is next.** No assertion says "this
+   must not touch the filesystem", so a mark silently becomes a hosted-CI-only
+   tripwire — the exact failure class that cost PR-13 three CI-only failures.
+   Phase 5 rewrites these very paths: PR-15 bug 3 changes the holdings-env lookup
+   in `abspath_for_logical_path`, and PR-16 moves `logical_path_from_abspath`,
+   `repair_case` and `selected_path_from_path` into `_path_utils.py`.
+4. **The plan enumerates the subset and this is not in it.** §1 G3: "the
+   holdings-free subset (API freeze, tool unit tests, import/collection smoke)".
+   The Phase-4 bullet's "any other no-data tests" is read against that
+   enumeration; the blackbox/whitebox suites are the data suite.
+
+Some of the 291 are also hollow on inspection — `test__info` asserts
+`res1 == res2`, `test_logical_path_from_abspath` swallows `ValueError` into
+`assert True` — which is a reason to be wary of them as a hosted-CI signal, not a
+reason on its own.
+
+The measurement and the option are recorded as entry 15 of
+`critiques/deferred-observations.md` so this is a decision on the record rather
+than a search that came up empty. No test was marked to make a number go up.
+
+## 5. How the marker is applied without editing the frozen test
+
+§6.4 forbids editing `tests/api/test_api_freeze.py`. Two mechanisms were
+considered:
+
+1. **A path predicate inside `tests/conftest.py`'s existing skip loop.** Rejected:
+   it edits PR-09's collect-and-skip machinery, which ground rule 3 says stays as
+   merged (PR-13 already needed an owner-accepted addendum to add the
+   `holdings_free` exemption at all), and it splits the "is this holdings-free"
+   answer across a marker *and* a hard-coded path.
+2. **A new `tests/api/conftest.py`** that marks every item collected from that
+   directory `holdings_free`. **Chosen.** It touches no frozen and no PR-09 file,
+   the fact lives next to the tests it describes, and it covers later additions
+   to `tests/api/` — `tests/api/test_mixin_collisions.py` arrives there in PR-17
+   and is equally holdings-free.
+
+Two properties of the chosen form were verified rather than assumed:
+
+- **Hook order.** `tests/conftest.py`'s `pytest_collection_modifyitems` adds the
+  skip to everything not already marked, so the marker must be applied first.
+  Conftest hook order is otherwise unspecified, so the new hook is declared
+  `@pytest.hookimpl(tryfirst=True)`. Verified by the run in §4: the freeze test
+  passes rather than skipping.
+- **Hermeticity under `--confcutdir=tests/api`.** That flag (used by the
+  API-freeze gate in `run-all-checks.sh`) loads `tests/api/conftest.py` but not
+  `tests/conftest.py`. The new file imports only `pathlib` and `pytest`, declares
+  no options — so `--mode`/`--update` still come from `tests/conftest.py` alone —
+  and registers no marker of its own (`holdings_free` is registered in
+  `pyproject.toml`, which `--strict-markers` reads). Verified: the hermetic
+  invocation passes.
+
+## 6. `--mode` hardening (deferred entry 12)
+
+Owner decision relayed 2026-07-26: `choices=('s', 'ns')` **and** `default='ns'`.
+
+- Survey of **every** `--mode` invocation in the repo — `scripts/automated_tests/
+  pdsfile_main_test.sh` (both passes), `scripts/run-all-checks.sh`,
+  `run_tests_coverage.sh`, `tests/rules/README.md`, `.cursor/rules`, the plans and
+  the critique records — found that all of them already pass an explicit `s` or
+  `ns`. No existing invocation changes behavior; both full-data set diffs in §3
+  are empty, which is the mechanical confirmation. (`run_tests_coverage.sh` at the
+  repo root passes valid modes but references pre-`src/`-layout paths that no
+  longer exist; it is stale independently of this PR and is left alone.)
+- Because the option can no longer hold any value but `s` or `ns`, the mixed
+  `else` branch (`Pds3File` shelves-only, `Pds4File` not — a state no invocation
+  ever selected and `# pragma: no cover` acknowledged) is **deleted**, not left
+  unreachable. `setup` now computes one `shelves_only` boolean and applies it to
+  both classes, so the two can no longer disagree.
+- Verified loud failure: `pytest tests/api --mode NS` now exits with
+  `error: argument --mode: invalid choice: 'NS' (choose from 's', 'ns')`.
+- `scripts/run-all-checks.sh` passes `--mode ns` explicitly, so the script does
+  not depend on the default and reads as its own documentation.
+
+## 7. Deferred entry 8 (subprocess coverage) — measured, then re-deferred
+
+Implemented as a spike and measured before deciding. Command, run twice with the
+limited holdings copy exported:
+
+```
+PDSFILE_TEST_HOLDINGS=full python -m coverage run -m pytest \
+    tests/holdings_maintenance/test_pds3_archives.py --mode ns -q -p no:cacheprovider
+```
+
+The only variable is whether `tests/holdings_maintenance/support.py::run_tool`
+prefixes each tool subprocess with
+`-m coverage run --parallel-mode --rcfile <repo>/pyproject.toml` and sets an
+absolute `COVERAGE_FILE` in the subprocess environment:
+
+| tool subprocesses | pytest summary line |
+|---|---|
+| uninstrumented (today) | `8 passed, 5 warnings in 16.06s` |
+| instrumented | `8 passed, 5 warnings in 138.84s` |
+
+**8.6x**, paid on every PR and nightly across four Python versions of the
+self-hosted gate. The cost is the tracer inside each tool, so the
+`sitecustomize`/`COVERAGE_PROCESS_START` route named in the entry measures the
+same and costs the same; it additionally needs parallel data files and a guarded
+`coverage combine` inside the data-gate driver. The spike was reverted; the entry
+is re-assigned to PR-37 with the measurements and the `COVERAGE_CORE=sysmon` lead
+recorded in `critiques/deferred-observations.md`. Nothing was half-landed.
+
+## 8. Workflow YAML — how it was validated, and what it cannot prove
+
+- Parsed with `yaml.safe_load`; the job graph was asserted programmatically:
+  `run-tests.yml` now has jobs `lint` (ubuntu-latest, matrix 3.10/3.13) and
+  `test` (self-hosted-linux, matrix 3.10–3.13, unchanged, including its codecov
+  upload gated on 3.13). `run-tests-and-opus.yml` is **unmodified**:
+  `test_pdsfile` still `uses: ./.github/workflows/run-tests.yml` and `test_opus`
+  still `needs: [test_pdsfile]`.
+- Effect of the new job on the OPUS workflow, checked explicitly: `needs` on a
+  reusable-workflow caller waits for the *whole* called workflow, so `test_opus`
+  now also waits for `lint`. Harmless and desirable — the OPUS leg no longer
+  starts behind a lint failure. No job id changed and no job was renamed, so the
+  existing check names are preserved and only new ones are added.
+- The lint job runs `scripts/run-all-checks.sh --sequential` rather than
+  re-listing the gates, which is how "CI runs exactly the set the script enables,
+  no more, no less" (`environment.mdc` §2/§3, tightened at PR-14) is satisfied by
+  construction rather than by hand-maintained parity.
+- Correspondence holds at the **workflow** level, i.e. over the union of the two
+  jobs, not per job: the self-hosted job runs
+  `scripts/automated_tests/pdsfile_main_test.sh`, which the PR-14 bullet says to
+  leave exactly as it is. That driver adds coverage and a second, pds3-only
+  `--mode s` pass which the script does not have, so a shelves-only-specific
+  failure is caught by CI and not by the script. Recorded in the script's
+  `# Environment:` header and in deviation (8) so nobody assumes the script
+  reproduces the data gate exactly.
+- The script was executed locally in exactly the hosted job's condition — all
+  four holdings env vars unset — and passed end to end in 21 s (§2). What that
+  does **not** prove is the stock-runner environment itself: a different
+  filesystem, TZ, locale and a fresh pip resolution on 3.10 and 3.13. The tests
+  that job runs were audited for that class of assumption (the `crlf` classifier
+  units build their own bytes in `tmp_path`; the holdings-free
+  `shelf_consistency_check` cases build their own tiny tree; the freeze test
+  shells out to the dumper and compares JSON). **First real proof comes from the
+  CI run on this PR.**
+
+## 8a. The Windows classifier, and why macOS keeps its own
+
+Owner decision (issue #102): drop `Operating System :: Microsoft :: Windows`.
+The reason is that the package is **not supported** on Windows — that is why
+PR-08 removed it from the matrix and why the issue exists. `Operating System ::
+MacOS :: MacOS X` is deliberately kept: macOS is a supported platform whose
+matrix entries are commented out in `run-tests.yml`, not deleted, and are
+re-enablable. "Untested in CI right now" is not the criterion; "unsupported" is.
+pyroma still scores 10/10 with the classifier list as it now stands.
+
+## 9. Not changed, deliberately
+
+- `scripts/automated_tests/pdsfile_main_test.sh` — the self-hosted full-data
+  driver, untouched (both passes, the `PDSFILE_TEST_HOLDINGS=full` export, the
+  coverage invocation and the codecov artifact).
+- The self-hosted matrix, its triggers (`pull_request` to `rewrite`, `push` to
+  `main`, nightly cron, `workflow_dispatch`, `workflow_call`), and the codecov
+  upload step.
+- PR-09's holdings-flavor machinery: `tests/support/holdings.py`, the
+  `PDSFILE_TEST_HOLDINGS` / `PDSFILE_TEST_DATA_DIR` env vars, the `full_holdings`
+  marker and its mini branch, `tests/golden/full/`. Nothing sets
+  `PDSFILE_TEST_DATA_DIR`.
+- Coverage thresholds and `codecov.yml` (targets stay informational until Phase
+  8).
+- **Nightly-failure alerting.** Settled decision §8.7 is GitHub's built-in
+  notifications for now, so this deliverable is "no work"; the nightly cron and
+  its notification behavior are unchanged, and nothing was added.
+- **Branch protection.** Settled decision §8.8 makes protecting `rewrite` an
+  owner/admin action. The check names to require once this lands are in the PR
+  description.

--- a/critiques/pr-14/validation.md
+++ b/critiques/pr-14/validation.md
@@ -296,8 +296,44 @@ recorded in `critiques/deferred-observations.md`. Nothing was half-landed.
   that job runs were audited for that class of assumption (the `crlf` classifier
   units build their own bytes in `tmp_path`; the holdings-free
   `shelf_consistency_check` cases build their own tiny tree; the freeze test
-  shells out to the dumper and compares JSON). **First real proof comes from the
-  CI run on this PR.**
+  shells out to the dumper and compares JSON). First real proof comes from the
+  CI run on this PR — see §8b.
+
+## 8b. First real CI run (PR #107, run 30217863593) — all six jobs green
+
+The stock-runner unknown is now closed. Every job succeeded on the first attempt;
+no PR-13-style environment-pinning failure appeared.
+
+**Hosted `Lint and holdings-free tests`**, both legs, on `ubuntu-latest` with no
+holdings and a fresh pip resolution:
+
+| leg | pytest line | result | wall |
+|---|---|---|---|
+| 3.10 | `Running pytest (-n 1; no holdings: holdings-free subset only)...` | **24 passed, 800 skipped** | 24 s total for all five gates |
+| 3.13 | same | **24 passed, 800 skipped** | comparable |
+
+Both legs also show `Final rating: 10/10` (pyroma), `✓ Ruff check passed`,
+`✓ API-freeze check passed`, and the clean-install gate building its throwaway
+venv and importing the full module surface — the first time that gate has run on
+a machine with no holdings env vars at all. The printed flavor line is the
+no-holdings branch, so the job is demonstrably running the subset it claims and
+not silently something else.
+
+**Self-hosted `Test pdsfile`**, all four Python versions green; the 3.13 leg's
+two passes read:
+
+```
+790 passed, 34 skipped in 378.62s      (--mode ns)
+555 passed,  3 skipped in 282.15s      (--mode s)
+```
+
+Identical to the baseline in §3 and to the local runs, on a different machine and
+a different holdings root — which independently corroborates the "no behavior
+change" claim rather than merely repeating it.
+
+The six check names GitHub produced match the ones given to the owner for branch
+protection exactly: `Lint and holdings-free tests (3.10)`, `(3.13)`, and
+`Test pdsfile (self-hosted-linux, 3.10 … 3.13)`.
 
 ## 8a. The Windows classifier, and why macOS keeps its own
 

--- a/critiques/pr-14/validation.md
+++ b/critiques/pr-14/validation.md
@@ -122,7 +122,7 @@ Command: `pytest tests` with `PDS3_HOLDINGS_DIR`, `PDS4_HOLDINGS_DIR`,
 `passed + skipped == collected` in both. The set difference of passing test ids
 is exactly one test, in one direction:
 
-```
+```text
 + PASSED tests/api/test_api_freeze.py::test_public_api_frozen
 ```
 
@@ -136,7 +136,7 @@ was measured, not eyeballed. The blanket skip was lifted with a throwaway
 `tryfirst` plugin marking every collected item `holdings_free`, and the whole
 tree was run with all four holdings env vars unset:
 
-```
+```text
 315 passed, 387 failed, 122 skipped
 ```
 
@@ -241,7 +241,7 @@ Owner decision relayed 2026-07-26: `choices=('s', 'ns')` **and** `default='ns'`.
 Implemented as a spike and measured before deciding. Command, run twice with the
 limited holdings copy exported:
 
-```
+```sh
 PDSFILE_TEST_HOLDINGS=full python -m coverage run -m pytest \
     tests/holdings_maintenance/test_pds3_archives.py --mode ns -q -p no:cacheprovider
 ```
@@ -322,7 +322,7 @@ not silently something else.
 **Self-hosted `Test pdsfile`**, all four Python versions green; the 3.13 leg's
 two passes read:
 
-```
+```text
 790 passed, 34 skipped in 378.62s      (--mode ns)
 555 passed,  3 skipped in 282.15s      (--mode s)
 ```

--- a/plans/2026-07-25-modernization-plan.md
+++ b/plans/2026-07-25-modernization-plan.md
@@ -190,12 +190,12 @@ for re-interpretation by the executor:
 | `ruff check` (ratcheted) | **Active** (PR-03) | Style; per-file-ignores may only shrink |
 | Clean-install import check | **Active** (PR-08) | `pip install .` with no extras; `import pdsfile` + every manifest module imports (runtime-dep leak guard) |
 | `ruff format --check` | PR-23 (core) / PR-24 (rest) — **conditional on the owner churn checkpoints in those PRs**; scope may be reduced or the gate dropped entirely | Formatting; not gated before the one-time reformat lands |
-| Hosted lint/no-holdings CI job | PR-14 | ruff + API-freeze + clean-install + the holdings-free test subset on stock GitHub runners |
+| Hosted lint/no-holdings CI job | **Active** (PR-14) | ruff + API-freeze + clean-install + the holdings-free test subset on stock GitHub runners |
 | sphinx -W -n build | PR-31 | Docs build clean |
 | Adversarial pre-PR review loop | **Active** (every PR) | A fresh, no-context reviewer cannot prove the PR misses its stated goal — zero Major and no new un-rebutted Minor findings (§6.6) |
 
 `scripts/run-all-checks.sh` is the single source of truth for the enabled set
-(`ENABLE_*` flags; currently on: ruff-check, pyroma, api-freeze,
+(`ENABLE_*` flags; currently on: ruff-check, pytest, pyroma, api-freeze,
 clean-install). Each PR that introduces a gate flips its flag and keeps CI in
 exact correspondence (`environment.mdc`). `ENABLE_MYPY`, `ENABLE_BANDIT`,
 `ENABLE_VULTURE` stay false permanently (ground rules / overrides).

--- a/plans/2026-07-25-modernization-plan.md
+++ b/plans/2026-07-25-modernization-plan.md
@@ -190,7 +190,7 @@ for re-interpretation by the executor:
 | `ruff check` (ratcheted) | **Active** (PR-03) | Style; per-file-ignores may only shrink |
 | Clean-install import check | **Active** (PR-08) | `pip install .` with no extras; `import pdsfile` + every manifest module imports (runtime-dep leak guard) |
 | `ruff format --check` | PR-23 (core) / PR-24 (rest) — **conditional on the owner churn checkpoints in those PRs**; scope may be reduced or the gate dropped entirely | Formatting; not gated before the one-time reformat lands |
-| Hosted lint/no-holdings CI job | **Active** (PR-14) | ruff + API-freeze + clean-install + the holdings-free test subset on stock GitHub runners |
+| Hosted lint/no-holdings CI job | **Active** (PR-14) | ruff + pyroma + API-freeze + clean-install + the holdings-free test subset on stock GitHub runners (it runs `run-all-checks.sh`, so it is whatever that enables) |
 | sphinx -W -n build | PR-31 | Docs build clean |
 | Adversarial pre-PR review loop | **Active** (every PR) | A fresh, no-context reviewer cannot prove the PR misses its stated goal — zero Major and no new un-rebutted Minor findings (§6.6) |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Operating System :: MacOS :: MacOS X",
-  "Operating System :: POSIX :: Linux",
-  "Operating System :: Microsoft :: Windows"
+  "Operating System :: POSIX :: Linux"
 ]
 
 [project.urls]

--- a/scripts/run-all-checks.sh
+++ b/scripts/run-all-checks.sh
@@ -36,9 +36,11 @@
 #   PDS3_HOLDINGS_DIR        Roots of the real holdings trees. Export both to run
 #   PDS4_HOLDINGS_DIR          the pytest gate as a full data suite; with neither
 #                              it runs the holdings-free subset and skips the
-#                              rest. Which run happened is printed.
-#   PDSFILE_TEST_HOLDINGS    Explicit tree selector (full|mini); set to full when
-#                              a root above is exported and it is not.
+#                              rest. Exporting only one is an error: the gate
+#                              fails and names the missing variable rather than
+#                              running the subset. Which run happened is printed.
+#   PDSFILE_TEST_HOLDINGS    Explicit tree selector (full|mini). Set to full when
+#                              either root above is exported and this is not.
 #
 #   The pytest gate here is ONE --mode ns pass over tests/. The self-hosted data
 #   gate (scripts/automated_tests/pdsfile_main_test.sh) runs that pass under

--- a/scripts/run-all-checks.sh
+++ b/scripts/run-all-checks.sh
@@ -12,7 +12,7 @@
 # Options:
 #   -p, --parallel         Run all requested checks in parallel (default)
 #   -s, --sequential       Run all requested checks sequentially
-#   -w, --pytest-workers N Pytest workers: auto (default), 1 (serial), or N
+#   -w, --pytest-workers N Pytest workers: 1 (serial, default), auto, or N
 #   -c, --code             Run all code checks (sets each RUN_* code flag true)
 #   -d, --docs             Run Sphinx and PyMarkdown (RUN_SPHINX, RUN_PYMARKDOWN)
 #   -m, --markdown         Run only PyMarkdown (RUN_PYMARKDOWN)
@@ -33,6 +33,18 @@
 #   VENV or VENV_PATH        Path to virtualenv (default: $PROJECT_ROOT/venv)
 #   CLEANUP_GRACE_PERIOD     Seconds to wait for graceful shutdown (default: 5)
 #
+#   PDS3_HOLDINGS_DIR        Roots of the real holdings trees. Export both to run
+#   PDS4_HOLDINGS_DIR          the pytest gate as a full data suite; with neither
+#                              it runs the holdings-free subset and skips the
+#                              rest. Which run happened is printed.
+#   PDSFILE_TEST_HOLDINGS    Explicit tree selector (full|mini); set to full when
+#                              a root above is exported and it is not.
+#
+#   The pytest gate here is ONE --mode ns pass over tests/. The self-hosted data
+#   gate (scripts/automated_tests/pdsfile_main_test.sh) runs that pass under
+#   coverage plus a second, pds3-only --mode s pass, so it is the authority on
+#   shelves-only behavior.
+#
 #   Pytest coverage minimum: configure fail_under in coverage config (e.g.
 #   pyproject.toml [tool.coverage.report] or .coveragerc [report]).
 #
@@ -46,7 +58,7 @@
 #     ENABLE_RUFF_CHECK   (default: true)
 #     ENABLE_RUFF_FORMAT  (default: false — not enforced yet)
 #     ENABLE_MYPY         (default: false — never; no inline typing)
-#     ENABLE_PYTEST       (default: false — not enabled yet)
+#     ENABLE_PYTEST       (default: true)
 #     ENABLE_PYROMA       (default: true)
 #     ENABLE_API_FREEZE   public-API freeze (default: true)
 #     ENABLE_CLEAN_INSTALL clean-install runtime-dep leak gate (default: true)
@@ -57,7 +69,7 @@
 #
 # Checks (each run separately; -d runs both Sphinx and Markdown):
 #   Code:     optional: ruff check, ruff format --check, mypy, pytest, pyroma,
-#             api-freeze, bandit, vulture (see ENABLE_* above)
+#             api-freeze, clean-install, bandit, vulture (see ENABLE_* above)
 #   Sphinx:   make -C docs html SPHINXOPTS="-W"
 #   Markdown: pymarkdown scan docs/ .cursor/ README.md CONTRIBUTING.md
 #
@@ -78,7 +90,10 @@ RESET='\033[0m'
 
 # Default options
 PARALLEL=true
-PYTEST_WORKERS=auto
+# Serial by default: with holdings present this gate is a full-data run, and each
+# xdist worker preloads its own copy of the holdings cache. Pass -w auto to
+# parallelize on a machine that can afford it.
+PYTEST_WORKERS=1
 RUN_RUFF_CHECK=false
 RUN_RUFF_FORMAT=false
 RUN_MYPY=false
@@ -96,13 +111,13 @@ SCOPE_SPECIFIED=false
 # permanently change here).
 #
 # Gates are enabled as they become able to pass. Currently enabled: ruff-check,
-# pyroma, api-freeze, and the clean-install gate. Not enabled yet: pytest
-# (hermetic), ruff-format, sphinx, and pymarkdown. Never enabled: mypy, bandit,
-# vulture (ground rules / pdsfile_overrides.mdc).
+# pytest, pyroma, api-freeze, and the clean-install gate. Not enabled yet:
+# ruff-format, sphinx, and pymarkdown. Never enabled: mypy, bandit, vulture
+# (ground rules / pdsfile_overrides.mdc).
 : "${ENABLE_RUFF_CHECK:=true}"
 : "${ENABLE_RUFF_FORMAT:=false}"
 : "${ENABLE_MYPY:=false}"
-: "${ENABLE_PYTEST:=false}"
+: "${ENABLE_PYTEST:=true}"
 : "${ENABLE_PYROMA:=true}"
 : "${ENABLE_API_FREEZE:=true}"
 : "${ENABLE_CLEAN_INSTALL:=true}"
@@ -421,11 +436,45 @@ run_code_checks() {
     # -n controls parallelism; --dist loadscope keeps each test module on one
     # worker to avoid cross-test interference. No -n/--cov live in pyproject
     # addopts (chosen per invocation), so they are passed here. This branch runs
-    # only when the pytest gate is enabled (ENABLE_PYTEST) and targets the
+    # only when the pytest gate is enabled (ENABLE_PYTEST) and targets the whole
     # top-level tests/ tree.
+    #
+    # --mode ns is the mode in which the whole tree passes; it is passed
+    # explicitly so this invocation does not depend on the option's default. Note
+    # this is one pass over everything, whereas the self-hosted data gate
+    # (scripts/automated_tests/pdsfile_main_test.sh) runs two: the same ns pass
+    # under coverage, then a pds3-only --mode s pass. A shelves-only-specific
+    # failure is therefore visible to that driver and not to this script.
     if [ "$RUN_PYTEST" = true ] && [ "$ENABLE_PYTEST" = true ]; then
-        print_info "Running pytest (-n ${PYTEST_WORKERS})..."
-        if python -m pytest -q -n "$PYTEST_WORKERS" --dist loadscope tests; then
+        # Which tree the suite runs against is chosen by PDSFILE_TEST_HOLDINGS
+        # (see tests/support/holdings.py); exporting the roots is not by itself
+        # enough. Either root present and no selector means someone meant to run
+        # against data, so select the full tree rather than quietly running the
+        # holdings-free subset and reporting success. With only one of the two
+        # exported the resolver then fails the session and names the missing
+        # variable, which is the point: half-configured is a mistake, not a
+        # 3%-of-the-suite pass. An explicit selector always wins.
+        if [ -z "${PDSFILE_TEST_HOLDINGS:-}" ] \
+                && { [ -n "${PDS3_HOLDINGS_DIR:-}" ] || [ -n "${PDS4_HOLDINGS_DIR:-}" ]; }; then
+            export PDSFILE_TEST_HOLDINGS=full
+        fi
+        # Report what the resolver actually resolved rather than re-deriving it
+        # here, so the log cannot disagree with the session.
+        holdings_flavor=$(python -c 'import sys; sys.path.insert(0, ".")
+from tests.support.holdings import resolve_holdings
+print(resolve_holdings().flavor or "none")' 2>/dev/null || echo 'unresolved')
+        case "$holdings_flavor" in
+            none)
+                print_info "Running pytest (-n ${PYTEST_WORKERS}; no holdings: holdings-free subset only)..."
+                ;;
+            unresolved)
+                print_info "Running pytest (-n ${PYTEST_WORKERS}; holdings selection is invalid, pytest will report it)..."
+                ;;
+            *)
+                print_info "Running pytest (-n ${PYTEST_WORKERS}; holdings: ${holdings_flavor})..."
+                ;;
+        esac
+        if python -m pytest -q -n "$PYTEST_WORKERS" --dist loadscope tests --mode ns; then
             print_success "Pytest passed"
         else
             print_error "Pytest failed"
@@ -445,10 +494,10 @@ run_code_checks() {
         fi
     fi
 
-    # Public-API freeze. --confcutdir=tests/api bypasses tests/conftest.py,
-    # which requires holdings env vars to import, so this check stays hermetic.
-    # The freeze test regenerates the manifest in a clean subprocess and needs
-    # no holdings itself.
+    # Public-API freeze. --confcutdir=tests/api collects the test without
+    # tests/conftest.py, so this check pulls in no session options, no holdings
+    # resolution and no preload. The freeze test regenerates the manifest in a
+    # clean subprocess and needs no holdings itself.
     if [ "$RUN_API_FREEZE" = true ] && [ "$ENABLE_API_FREEZE" = true ]; then
         print_info "Running API-freeze check..."
         if python -m pytest tests/api/test_api_freeze.py --confcutdir=tests/api -p no:cacheprovider -q; then

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,0 +1,48 @@
+##########################################################################################
+# tests/api/conftest.py
+#
+# Everything under tests/api/ checks the public API surface itself, never the
+# holdings data: the freeze test regenerates the manifest in a clean child
+# interpreter and compares it against the committed one. So every test collected
+# from this directory is holdings-free and must run on a machine with no holdings
+# tree -- including the hosted no-holdings CI job.
+#
+# tests/conftest.py skips every collected item that does not carry the
+# holdings_free marker when no holdings are available. Rather than marking each
+# module (tests/api/test_api_freeze.py is frozen and must not be edited -- see the
+# section 6.4 prohibitions in plans/2026-07-25-modernization-plan.md), the marker is
+# applied here to everything collected from this directory, which also covers
+# future additions.
+#
+# That makes "no test in this directory needs holdings" a rule of the directory,
+# not an observation about the files currently in it. A test added here that does
+# need a holdings tree will fail on a runner without one instead of skipping --
+# loudly, on the first run, which is the intended signal. Such a test belongs
+# somewhere else in the tree.
+#
+# This file is deliberately dependency-free apart from pytest: the API-freeze check
+# in scripts/run-all-checks.sh runs with --confcutdir=tests/api, which loads this
+# conftest but not tests/conftest.py, and that invocation must stay hermetic. It
+# also declares no options, so the session's --mode/--update options keep coming
+# from tests/conftest.py alone.
+##########################################################################################
+
+from pathlib import Path
+
+import pytest
+
+# Resolved, because the collected item paths are resolved too: if the checkout is
+# reached through a symlink, an unresolved comparison quietly stops matching and
+# the marker stops being applied.
+_API_TESTS_DIR = Path(__file__).resolve().parent
+
+
+# tryfirst: tests/conftest.py's pytest_collection_modifyitems adds the no-holdings
+# skip to every item that is not already marked holdings_free, so this marker has to
+# be in place before that hook runs. Conftest hook order is otherwise unspecified.
+@pytest.hookimpl(tryfirst=True)
+def pytest_collection_modifyitems(items):
+    holdings_free = pytest.mark.holdings_free
+    for item in items:
+        if item.path is not None and item.path.resolve().is_relative_to(_API_TESTS_DIR):
+            item.add_marker(holdings_free)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,10 @@ from tests.support.holdings import resolve_holdings, SKIP_REASON
 # Setup before all tests
 ##########################################################################################
 def pytest_addoption(parser):
-    parser.addoption("--mode", action="store")
+    # 'ns' is the default because it is the broader pass: every test directory runs
+    # under it, while 's' covers pds3 only. choices makes a mistyped mode a loud
+    # usage error rather than a silently different session.
+    parser.addoption("--mode", action="store", choices=('s', 'ns'), default='ns')
     parser.addoption("--update", action="store_true")
 
 def pytest_configure(config):
@@ -63,16 +66,13 @@ def setup(request):
         # Every test is skipped; there is nothing to preload.
         return
 
-    mode = request.config.option.mode
-    if mode == 's':
-        Pds3File.use_shelves_only(True)
-        Pds4File.use_shelves_only(True)
-    elif mode == 'ns':
-        Pds3File.use_shelves_only(False)
-        Pds4File.use_shelves_only(False)
-    else: # pragma: no cover
-        Pds3File.use_shelves_only(True)
-        Pds4File.use_shelves_only(False)
+    # --mode is restricted to 's'/'ns' and defaults to 'ns', so the two modes are
+    # exhaustive: 's' is shelves-only for both classes, 'ns' is neither. The two
+    # classes are always set together; a session where they disagree is not a mode
+    # the suite exercises.
+    shelves_only = request.config.option.mode == 's'
+    Pds3File.use_shelves_only(shelves_only)
+    Pds4File.use_shelves_only(shelves_only)
 
     # turn_on_logger("test_log.txt")
     Pds3File.preload(holdings.pds3_root)


### PR DESCRIPTION
Phase 4 of the modernization plan (`plans/2026-07-25-modernization-plan.md`, PR-14). Adds stock-runner coverage, turns on the pytest gate, and brings CI and `scripts/run-all-checks.sh` into the exact correspondence `environment.mdc` asks for. The self-hosted full-data gate is untouched.

Closes #102.

## What landed

**A hosted `lint` job in `run-tests.yml`** — `ubuntu-latest`, Python 3.10 and 3.13 (floor and ceiling; the self-hosted matrix covers all four with data). It runs `scripts/run-all-checks.sh --sequential` rather than naming gates, so CI cannot drift from the script: ruff check, pyroma, the API-freeze check, the clean-install gate, and pytest with no holdings env vars set — which collects the whole tree, runs the holdings-free tests and skips the rest. That run is itself the regression test for PR-09's graceful skip.

**The self-hosted full-data matrix is unchanged** — same triggers (`pull_request` to `rewrite`, `push` to `main`, nightly cron, dispatch, `workflow_call`), same driver `scripts/automated_tests/pdsfile_main_test.sh`, same codecov upload gated on 3.13. `run-tests-and-opus.yml` is not in the diff. Because `needs:` on a reusable-workflow caller waits for the whole called workflow, `test_opus` now also waits for `lint` — harmless and desirable; no job id changed and no job was renamed, so existing check names are preserved and only new ones are added.

**`ENABLE_PYTEST=true` in `run-all-checks.sh`**, with two guards so the newly enabled gate is honest:

- It runs **serially** by default (`-w 1`). With holdings present this is a full-data run and each xdist worker preloads its own holdings cache (~105 MB measured per preload against the limited copy); the plan retired xdist adoption and deviation (7) says full-data runs are serial. `-w auto` is still available and was measured at 33.9 s vs 142.1 s with an identical pass/skip set.
- It selects the full holdings tree whenever a holdings root is exported without `PDSFILE_TEST_HOLDINGS`, and prints the flavor `resolve_holdings()` actually chose. Without that, the environment §3.4 describes (export the two roots, nothing more) produced 24 passed / 800 skipped and a green `SUCCESS` — 3% of the suite reported as a pass. Exporting only one root now fails and names the missing variable. An explicit selector always wins and `PDSFILE_TEST_DATA_DIR` is never set, so PR-09's mini flavor stays dormant.

**`.cursor/rules/pdsfile_overrides.mdc` deviation (8)** now records the matrix that exists — self-hosted Linux 3.10–3.13 full-data plus the hosted ubuntu lint job — instead of the withdrawn 3-OS aim, including that the two jobs run different drivers and only their union matches the script's enabled set (the data driver adds coverage and a pds3-only `--mode s` pass).

**`pyproject.toml`** drops `Operating System :: Microsoft :: Windows`. macOS keeps its classifier: it is supported and its matrix entries are commented out rather than deleted.

## Validation

Holdings resolved entirely from `PDS3_HOLDINGS_DIR` / `PDS4_HOLDINGS_DIR` with `PDSFILE_TEST_HOLDINGS=full`, against the limited testing copy the goldens are tuned to. Full record: [`critiques/pr-14/validation.md`](critiques/pr-14/validation.md).

**Full-data suite — unchanged, per test, not just per count.** Both invocations were also run in a clean worktree at `origin/rewrite` and the sorted per-test outcome lines diffed:

| Run | `origin/rewrite` | this branch | diff |
|---|---|---|---|
| `--mode ns` (api, holdings_maintenance, pds3file, rules/pds3, pds4file, rules/pds4) | 790 passed / 34 skipped | 790 passed / 34 skipped | **empty** |
| `--mode s` (pds3file, rules/pds3) | 555 passed / 3 skipped | 555 passed / 3 skipped | **empty** |

**No-holdings run — this is what changes.** 824 collected, 0 collection errors, both before and after:

| | `origin/rewrite` | this branch |
|---|---|---|
| passed | 23 | **24** |
| skipped | 801 | **800** |

Exactly one test moves, in one direction: `tests/api/test_api_freeze.py::test_public_api_frozen`. Nothing stopped passing.

**This PR touches no file under `src/pdsfile/`**, so §6.6's full-data-record staleness rule cannot apply.

Other gates: ruff clean with the ratchet untouched; pyroma 10/10 after the classifier drop; API-freeze green in both invocations (hermetic `--confcutdir=tests/api` and whole-tree); clean-install green — including, for the first time, with no holdings env vars set.

## Deferred-observation dispositions

**Entry 9 — resolved.** The API-freeze test now runs without holdings. §6.4 forbids editing `tests/api/test_api_freeze.py`, so a new `tests/api/conftest.py` marks everything collected from that directory `holdings_free` (`tryfirst`, so the marker lands before the blanket skip; resolved paths on both sides so a symlinked checkout cannot silently break it). That makes "nothing here needs holdings" a rule of the directory, covering `tests/api/test_mixin_collisions.py` when PR-17 adds it. The file imports only `pathlib` and `pytest` and declares no options, so the hermetic freeze invocation stays hermetic.

The entry's "and any other genuinely holdings-free test" half was surveyed **by measurement**: with the blanket skip lifted, 315 pass with no holdings, i.e. 291 beyond the 24 the job runs. They are deliberately **not** marked — they do not build their own inputs but concatenate the *resolved* root, which with no holdings is PR-09's synthetic `/pdsfile-no-holdings/...` placeholder (visible in the test ids); 41 test functions are mixed at the parametrized-case level so there is no boundary to mark along; nothing pins the property, making a mark a hosted-CI-only tripwire right before Phase 5 rewrites those paths; and §1 G3 enumerates the subset as "API freeze, tool unit tests, import/collection smoke". Recorded with the numbers as entry 15, owned by issue #92.

**Entry 12 — resolved** (owner decision). `--mode` gains `choices=('s','ns')` and `default='ns'`. The mixed `Pds3File`-shelves-only / `Pds4File`-not branch is deleted rather than left unreachable: the fixture derives one `shelves_only` boolean and applies it to both classes. Every `--mode` call site in the repo was surveyed and all already passed an explicit valid mode, which is why both full-data diffs are empty. `run-all-checks.sh` passes `--mode ns` explicitly so it does not depend on the default. `--mode NS` now fails loudly.

**Entry 8 — measured, then re-deferred to PR-37, not half-landed.** Implemented as a spike first. One tool-test module, the only variable being whether each tool subprocess is wrapped in `coverage run --parallel-mode`: `8 passed in 16.06s` → `8 passed in 138.84s`, an **8.6x** slowdown paid on every PR and nightly across four Python versions of the self-hosted gate. The cost is the tracer inside each tool, so the `sitecustomize`/`COVERAGE_PROCESS_START` route named in the entry costs the same; it also needs parallel data files and a guarded `coverage combine` in the data-gate driver. The spike was reverted — no file under `tests/holdings_maintenance/` is in this diff. Re-assigned to PR-37 (where codecov targets get set) with the command line, raw timings and the `COVERAGE_CORE=sysmon` lead recorded.

**Entry 13 — noted.** `pdsfile_main_test.sh` is untouched, so the two-pass split and the tool tests' `--mode ns`-only placement are unchanged. The third invocation this PR adds runs the whole tree once under `--mode ns` — the same mode those tests already ran in — so the coupling is unchanged and PR-28 still owns re-deriving it.

Entries **15–21** are new, from the review rounds.

## Adversarial review (§6.6)

Four rounds, each a fresh no-context opus-class reviewer; converged. [`round-1`](critiques/pr-14/round-1.md) · [`round-2`](critiques/pr-14/round-2.md) · [`round-3`](critiques/pr-14/round-3.md) · [`round-4`](critiques/pr-14/round-4.md) · [`topology`](critiques/pr-14/topology.md)

- **Round 1** (1 Major): the holdings-free survey's stated reasoning was false — many data-suite tests do pass without holdings. Fixed the records with the measurement; rebutted the demand to mark them (above). Also made the pytest gate serial by default and stopped comments from re-listing the gate set.
- **Round 2** (1 Major): the newly-enabled gate passed vacuously on a machine configured the way §3.4 describes. Fixed.
- **Round 3** (0 Major, `goal met`): the vacuity guard only fired when *both* roots were set, and the flavor was inferred in shell rather than asked of the resolver. Both fixed; one finding rebutted as scope creep and deferred (entry 20).
- **Round 4** (scoped, 0 Major, `goal met`): confirmed every prior finding resolved, including re-running the freeze check through a symlinked checkout.

## Owner actions

**Branch protection** (settled decision §8.8 — owner/admin, not an executor task). Once this merges, the checks to mark required on `rewrite` are:

- `Lint and holdings-free tests (3.10)`
- `Lint and holdings-free tests (3.13)`
- `Test pdsfile (self-hosted-linux, 3.10)` … `(self-hosted-linux, 3.13)`

Please confirm the exact strings from this PR's own check list before setting them — GitHub composes matrix job names from the job `name:` plus its matrix values.

**Nightly-failure alerting**: settled decision §8.7 — GitHub's built-in notifications for now. No work; the cron and its notification behavior are unchanged.

**Not proven until CI runs.** The script was executed locally in exactly the hosted job's condition (all four holdings env vars unset) and passes end to end in ~15 s. What that cannot prove is the stock-runner environment itself — different filesystem, TZ, locale, and a fresh pip resolution on 3.10 and 3.13. The tests that job runs were audited for that class of assumption; first real proof is this PR's own CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QyABhcZoxQaRjUjRnguHPK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a hosted lint + validation CI job (Python 3.10/3.13).
  * Improved holdings-aware test selection behavior.
  * Automatically applies holdings-free classification to API tests.

* **Bug Fixes**
  * `--mode` is now strictly validated (`s`/`ns`) and fails fast on invalid values.
  * Default pytest execution is serial for more consistent gated runs.
  * Updated platform support metadata and CI/validation behavior to match reality.

* **Documentation**
  * Refreshed modernization-plan and CI validation guidance; expanded adversarial review/validation records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->