### PR TITLE
refactor: extract module-level path helpers → _path_utils.py

### DIFF
--- a/critiques/deferred-observations.md
+++ b/critiques/deferred-observations.md
@@ -552,3 +552,39 @@ each is recorded rather than fixed.
     pre-existing — it is only reachable at all now that the function no longer
     raises `NameError` first — and turning it into a graceful return is a new
     behavior, not a bug fix. **Owner:** whichever PR next revisits the icon path.
+
+## From PR-16 (extract module-level path helpers, Phase 5)
+
+Both raised by the PR-16 adversarial review. Neither is fixable inside a pure
+move PR: the first is process, the second is a pre-existing defect in code that
+moved byte-for-byte and is outside PR-15's enumerated bug list.
+
+29. **An extraction sweep must ask which module namespaces the tests *patch*, not
+    only which globals the code *reads*.** PR-16's free-variable sweep answered
+    "what must move with the code" correctly and completely. It could not have
+    caught what the review did: `tests/core/test_pdsfile_path_resolution.py`
+    replaced `glob` on `pdsfile.pdsfile`, so after the move the stub sat on a
+    namespace `abspath_for_logical_path` no longer resolves through, and the
+    test's outcome became a property of the machine rather than of the test. It
+    still *passed*, so §6.2's outcome-set diff — which compares pass/fail, not
+    what a test actually exercises — is structurally blind to it. The missing
+    step is a one-line grep for `monkeypatch.setattr` / `setattr(<module>` over
+    `tests/` and `scripts/` naming any module a PR moves code out of. PR-16 fixed
+    its own site by patching the function's `__globals__`, which follows the
+    function; the general step belongs in every later extraction PR's checklist.
+    It matters most for **PR-17**, which moves the `os`-resolving filesystem
+    helpers, where a stale `os` patch would be both likelier and harder to spot.
+    **Owner:** PR-17 onward (a step in each extraction PR's sweep).
+
+30. **`repair_case` raises `UnboundLocalError` on a single-component path.**
+    `_path_utils.py`'s `repair_case` assigns `found` only inside
+    `for k in range(1, len(parts))` but reads it unconditionally after the loop,
+    so any path that splits into one component skips the assignment:
+    `repair_case('/', Pds3File)` raises `UnboundLocalError: cannot access local
+    variable 'found'`. `repair_case('/tmp', Pds3File)` is fine, so only the
+    filesystem root and an empty-ish path reach it. Pre-existing and moved
+    byte-for-byte by PR-16; it is not in PR-15's enumerated bug list, and PR-16
+    is a pure move with no licence to change behavior. The fix is a
+    `found = True` initialization (a path with nothing to repair *is* found), but
+    that is a behavior change on a currently-raising input and needs its own test
+    and PR. **Owner:** PR-23, or whichever PR next edits this file.

--- a/critiques/deferred-observations.md
+++ b/critiques/deferred-observations.md
@@ -588,3 +588,32 @@ moved byte-for-byte and is outside PR-15's enumerated bug list.
     `found = True` initialization (a path with nothing to repair *is* found), but
     that is a behavior change on a currently-raising input and needs its own test
     and PR. **Owner:** PR-23, or whichever PR next edits this file.
+
+### Added by the PR-16 adversarial review (round 2)
+
+31. **`src/pdsfile/__init__.py:10`'s `from pdsfile import *` binds nothing.** It
+    is a self-import: when it executes, `sys.modules['pdsfile']` is the
+    partially-initialized package, whose namespace holds only dunders and
+    `__version__`, and a star import with no `__all__` skips every underscore
+    name. Reproduced in a throwaway package with the identical shape — the
+    statement contributes zero names. It reads as an intended
+    `from .pdsfile import *`, which would be a very different thing: it would
+    hoist every public name of `pdsfile.pdsfile` (including `repair_case`,
+    `abspath_for_logical_path`, `PATH_EXISTS_CACHE_SIZE` …) onto the package,
+    which is **not** the surface `tests/api/api_manifest.json` records for
+    `pdsfile`. So this cannot simply be "fixed": deleting it and correcting it
+    are both public-surface changes, one shrinking and one growing. It is also
+    why `F403`/`F841` sit in that file's ratchet entry. Untouched by PR-16.
+    **Owner:** PR-24, or whichever PR next revisits `__init__.py` — with an
+    explicit decision about which of the two readings is intended.
+
+32. **A commented-out line of dead code rode along with the move.**
+    `src/pdsfile/_path_utils.py`, inside `_clean_join`:
+    `#     joined = _clean_join(a,b).replace('\\', '/')`. PR-16 moved it
+    byte-for-byte, which is correct — editing it would have been a content change
+    inside a move PR. PR-22's brief is to "remove commented-out dead code
+    (~89 lines) — listed line-by-line in the PR", and its line list was drawn
+    against `pdsfile.py`; this line is no longer in that file. Recorded so the
+    line list is rebuilt against the post-Phase-5 module set rather than the
+    pre-split one. **Owner:** PR-22 (with PR-23 for the extracted modules'
+    style).

--- a/critiques/deferred-observations.md
+++ b/critiques/deferred-observations.md
@@ -555,11 +555,13 @@ each is recorded rather than fixed.
 
 ## From PR-16 (extract module-level path helpers, Phase 5)
 
-Four entries, all raised by the PR-16 adversarial review; 29 and 30 in round 1,
-31 and 32 in round 2. None is fixable inside a pure move PR: 29 is process, 30 is
-a pre-existing defect in code that moved byte-for-byte and is outside PR-15's
-enumerated bug list, 31 would change the public surface in whichever direction it
-were resolved, and 32 belongs to the PR that owns dead-code removal.
+Six entries, all raised by the PR-16 adversarial review; 29 and 30 in round 1,
+31 and 32 in round 2, 33 and 34 in round 4. None is fixable inside a pure move
+PR: 29 is process, 30 is a pre-existing defect in code that moved byte-for-byte
+and is outside PR-15's enumerated bug list, 31 would change the public surface in
+whichever direction it were resolved, 32 belongs to the PR that owns dead-code
+removal, and 33 and 34 are pre-existing conditions of files PR-16 does not
+touch.
 
 29. **An extraction sweep must ask which module namespaces the tests *patch*, not
     only which globals the code *reads*.** PR-16's free-variable sweep answered
@@ -628,3 +630,33 @@ were resolved, and 32 belongs to the PR that owns dead-code removal.
     line list is rebuilt against the post-Phase-5 module set rather than the
     pre-split one. **Owner:** PR-22 (with PR-23 for the extracted modules'
     style).
+
+### Added by the PR-16 adversarial review (round 4)
+
+33. **`scripts/gen_ruff_ratchet.py` cannot be exercised against the current
+    tree.** Its docstring workflow is "re-run this after a shrink and confirm the
+    diff only removes codes", but it runs `ruff check` with the project config,
+    whose committed `per-file-ignores` already suppress every violation, so it
+    emits an empty block. Reproducing a ratchet regeneration therefore requires
+    clearing the table first, which the script does not do and does not document.
+    Pre-existing and not touched by PR-16; noted because the ratchet is a
+    standing §2 gate and PR-23/PR-24 both lean on exactly that workflow when they
+    shrink the entries to their enumerated freeze-locked sets. **Owner:** PR-23.
+
+34. **Six pre-existing tracked files carry multi-component fragments of the real
+    holdings roots.** §3.4 requires that no absolute holdings path appear in
+    committed code, tests, docs, CI or `critiques/` records. Measured by scanning
+    every tracked file for any run of two or more consecutive components of
+    either root: `tests/pds3file/test_pds3file_whitebox.py`,
+    `plans/archive/2026-07-17-modernization-plan.md`,
+    `critiques/2026-07-21-unified-mini-holdings-analysis.md`,
+    `critiques/pr-02/validation.md`, `critiques/pr-14/round-1.md` and
+    `critiques/pr-14/validation.md`. No complete root appears in any of them; the
+    longest run is 29 characters, in the archived v1 plan. PR-16 does not touch
+    any of these files and cleaning them is outside a pure move PR's goal, so
+    they are recorded rather than fixed — but one of them is a **test module**,
+    which is the one category where a fragment could also become a portability
+    problem rather than only a disclosure one. The scan is a few lines and would
+    make a reasonable addition to `run-all-checks.sh` if the owner wants the rule
+    enforced rather than observed. **Owner:** owner decision, then PR-24 (records
+    and the archived plan) and PR-36 (the test module, via the critique pass).

--- a/critiques/deferred-observations.md
+++ b/critiques/deferred-observations.md
@@ -555,9 +555,11 @@ each is recorded rather than fixed.
 
 ## From PR-16 (extract module-level path helpers, Phase 5)
 
-Both raised by the PR-16 adversarial review. Neither is fixable inside a pure
-move PR: the first is process, the second is a pre-existing defect in code that
-moved byte-for-byte and is outside PR-15's enumerated bug list.
+Four entries, all raised by the PR-16 adversarial review; 29 and 30 in round 1,
+31 and 32 in round 2. None is fixable inside a pure move PR: 29 is process, 30 is
+a pre-existing defect in code that moved byte-for-byte and is outside PR-15's
+enumerated bug list, 31 would change the public surface in whichever direction it
+were resolved, and 32 belongs to the PR that owns dead-code removal.
 
 29. **An extraction sweep must ask which module namespaces the tests *patch*, not
     only which globals the code *reads*.** PR-16's free-variable sweep answered
@@ -574,6 +576,15 @@ moved byte-for-byte and is outside PR-15's enumerated bug list.
     function; the general step belongs in every later extraction PR's checklist.
     It matters most for **PR-17**, which moves the `os`-resolving filesystem
     helpers, where a stale `os` patch would be both likelier and harder to spot.
+
+    **Extended by the PR-16 round-3 review:** the same asymmetry exists one level
+    down, for module-level *data* rather than modules. `FILE_BYTE_UNITS` is
+    re-exported by `pdsfile.pdsfile` but read by `formatted_file_size` through
+    `_path_utils`'s globals, so mutating the list in place still works while
+    *rebinding* `pdsfile.pdsfile.FILE_BYTE_UNITS` is now silently inert. Measured:
+    no consumer anywhere does either, so nothing is broken today. PR-17 moves
+    `PATH_EXISTS_CACHE_SIZE` and hits the same shape, so the sweep step should
+    cover rebinding of re-exported data, not only of modules.
     **Owner:** PR-17 onward (a step in each extraction PR's sweep).
 
 30. **`repair_case` raises `UnboundLocalError` on a single-component path.**

--- a/critiques/phase5-validation.md
+++ b/critiques/phase5-validation.md
@@ -425,3 +425,214 @@ spawned (§6.6 step 5). Rounds 3 and 4 touched only `tests/` and `critiques/`,
 which under that same rule does not stale the record; the counts were
 regenerated after round 3 anyway, because it added a test and therefore changed
 the set.
+
+---
+
+## PR-16 — `refactor: extract module-level path helpers → _path_utils.py`
+
+**Branch:** `pr-16-path-utils`, based on `pr-15-latent-bug-fixes` @ `1a5d85c`
+("docs: reflow two record paragraphs"), opened against that branch, not `rewrite`
+(`plans/2026-07-26-addendum-phase5-stacked-prs.md`).
+**Baseline:** **PR-15's recorded post-fix set** — §3b above, `--mode ns` 825
+passed / 34 skipped (859 ids) and `--mode s` 555 passed / 3 skipped (558 ids) —
+**re-measured locally on the parent tip** with this PR's own command lines rather
+than copied from the table, exactly as PR-15 re-measured `rewrite`'s. The
+re-measurement reproduced §3b exactly.
+**Date:** 2026-07-27
+**Sub-plan:** [`plans/2026-07-27-pr-16-subplan.md`](../plans/2026-07-27-pr-16-subplan.md)
+**Last change under `src/pdsfile/`:** the extraction commit. Every run recorded
+below was generated after it.
+
+This PR is a pure extraction. Unlike PR-15 it has **no licence to move the
+pass/fail set in either direction**, so the gate here is simply "the two set
+diffs are empty", and the section is correspondingly short.
+
+### 1. Environment
+
+| Item | Value |
+|---|---|
+| Interpreter | CPython 3.12.3, repo venv, `pip install -e ".[dev]"` |
+| Holdings | `PDS3_HOLDINGS_DIR` / `PDS4_HOLDINGS_DIR` + `PDSFILE_TEST_HOLDINGS=full`, pointed at the limited testing copy the goldens are tuned to |
+| Baseline tree | `git worktree` at the parent tip `1a5d85c`, same interpreter, same holdings |
+| Command lines | exactly those in `scripts/automated_tests/pdsfile_main_test.sh` (serial, under `coverage`), plus `-rA --junitxml` |
+
+### 2. Active §2 gates
+
+| Gate | Result |
+|---|---|
+| API-freeze manifest test | **passed**; and the dumped surface is byte-identical to the parent's — §4 |
+| Full-data suite, both modes | **passed** — both set diffs empty; §3 |
+| `ruff check src/pdsfile tests scripts` | **passed**; the ratchet gained no code — §5 |
+| Clean-install import check | **passed** (throwaway venv, `pip install .`, full module surface imports) |
+| Hosted lint/no-holdings job (`scripts/run-all-checks.sh`, no holdings env vars) | **passed**, 59 passed / 800 skipped — identical to PR-15's §4 |
+| Adversarial review loop | `critiques/pr-16/round-<k>.md` |
+
+### 3. Full-data suite — both set diffs empty
+
+Both passes were run on the parent tip and on this branch's head with the same
+interpreter and the same holdings. Every `testcase` element of each `--junitxml`
+was reduced to one `outcome<TAB>classname::name` line, sorted, and the two files
+were diffed with `diff -u`.
+
+| Run | parent `1a5d85c` | `pr-16-path-utils` | set diff |
+|---|---|---|---|
+| `--mode ns` | 825 passed / 34 skipped (859 ids) | 825 passed / 34 skipped (859 ids) | **empty** |
+| `--mode s` | 555 passed / 3 skipped (558 ids) | 555 passed / 3 skipped (558 ids) | **empty** |
+
+No test id was added, removed, or changed outcome, in either mode. The parent
+numbers reproduce §3b's recorded set, which is what makes this a comparison
+against PR-15's baseline rather than against a fresh unrelated measurement.
+
+### 4. API freeze — empty diff, as a pure extraction requires
+
+1. `pytest tests/api/` passes. `tests/api/api_manifest.json`,
+   `tests/api/manifest_allowlist.json`, `scripts/dump_public_api.py` and
+   `tests/api/test_api_freeze.py` are untouched by this PR (§6.4); no allowlist
+   entry was added.
+2. `scripts/dump_public_api.py` was run against a worktree at the parent tip and
+   against this branch's head. The two dumps are **byte-identical** (733,876
+   bytes each, `diff` empty).
+
+The manifest records `pdsfile.pdsfile`'s module-level names including imported
+modules, so this gate is stricter here than it looks: dropping the now-unreferenced
+`import glob` / `import math` would have been a manifest break. See §5.
+
+`pdsfile._path_utils` is underscore-prefixed, so the dumper skips it where the
+submodule import binds it onto the `pdsfile` package — which is exactly the
+freeze-invisibility the Phase-5 preamble requires of a new internal name.
+
+### 5. What moved, and the sweep that decided it
+
+Ten module-level symbols, located by name (the plan's ":47–247" window had
+drifted — PR-15 edited this file): `construct_category_list`,
+`logical_path_from_abspath`, `_clean_join`, `_clean_abspath`, `_clean_glob`,
+`_needs_glob`, `repair_case`, `formatted_file_size`, `abspath_for_logical_path`,
+`selected_path_from_path`. `abspath_for_logical_path` moved in its **PR-15 form**
+— it reads `cls._HOLDINGS_ENV`; the pre-PR-15 hard-coded `'PDS3_HOLDINGS_DIR'`
+literal was not resurrected, and `tests/core/test_pdsfile_path_resolution.py`
+(five ids, all still passing) is what says so.
+
+**The sweep was computed, not read.** CPython's `symtable` yields the
+module-global names each moved function's body references; a second AST pass
+covers each definition's decorator expressions and argument defaults, which are
+evaluated in module scope and which `symtable` does not attribute to the
+function. Result:
+
+| Category | Found |
+|---|---|
+| module-level **constants** referenced | `FILE_BYTE_UNITS`, **`_GLOB_CACHE_SIZE`** |
+| module-level **classes** referenced (import-cycle risk) | **none** |
+| module-level **functions** that would stay behind | **none** |
+| unclassified names | **none** |
+| stdlib imports the moved set needs | `fnmatch`, `functools`, `glob`, `math`, `os` |
+
+The second pass is load-bearing, and this is the "record the method so a reviewer
+can check it" case the plan's sweep requirement exists for: `_GLOB_CACHE_SIZE`
+appears **only** in `@functools.lru_cache(maxsize=_GLOB_CACHE_SIZE)`, so a
+body-only sweep reports it as unreferenced and the extracted module raises
+`NameError` at import. The plan's brief names `FILE_BYTE_UNITS` alone; the sweep
+found the second one. `_GLOB_CACHE_SIZE` is private, has no other reference
+anywhere in the tree, and is therefore **not** re-exported; `FILE_BYTE_UNITS` is
+public and is.
+
+`PATH_EXISTS_CACHE_SIZE` was left alone — its consumer is the `lru_cache` on
+`os_path_exists`, which moves with `_local_fs.py` in PR-17.
+
+**No import cycle:** `_path_utils.py`'s module-level imports are `fnmatch`,
+`functools`, `glob`, `math`, `os` and nothing else — verified by parsing the
+module, not by reading it. No moved function needs a `PdsFile` class object, so
+no function-local deferred import was needed.
+
+**Byte-for-byte equivalence, measured.** For each moved definition the exact
+source segment (decorators included) was extracted from the parent commit's
+`pdsfile.py` and from `_path_utils.py` and compared byte by byte: all ten
+functions and both constants identical. The contiguous run from the first moved
+`def` to the last also compares identical as a single 6,562-byte blob, which
+additionally rules out a reordering or a dropped blank line. No moved body was
+restyled to dodge an inherited lint violation — that is PR-23's job.
+
+`pdsfile.pdsfile.X is pdsfile._path_utils.X` for all eleven re-exported names,
+so callers get the same objects, not copies.
+
+`pdsfile.py`: 6,308 → 6,122 lines; `_path_utils.py`: 219 lines.
+
+### 6. Keeping `pdsfile.pdsfile.X` resolving without touching the ratchet
+
+Four names in `pdsfile.py` are now referenced nowhere in it but are frozen
+members of its public surface: `FILE_BYTE_UNITS`, `selected_path_from_path`,
+`glob` and `math`. Measured rather than assumed — rewriting the four statements
+in plain form and re-running `ruff` produces exactly four F401s and no others:
+
+```
+F401 `glob` imported but unused
+F401 `math` imported but unused
+F401 `._path_utils.FILE_BYTE_UNITS` imported but unused
+F401 `._path_utils.selected_path_from_path` imported but unused
+```
+
+`pdsfile.py`'s ratchet entry does not contain F401, and the ratchet header in
+`pyproject.toml` forbids both growing it and adding an inline `noqa`. All four
+therefore use the PEP-484 redundant-alias form (`import glob as glob`,
+`FILE_BYTE_UNITS as FILE_BYTE_UNITS`), which ruff recognises as an explicit
+re-export. `pdsfile.py` now reports **0** F401 with no suppression of any kind.
+
+### 7. Ruff ratchet — no code gained
+
+Procedure: for every code in `pdsfile.py`'s entry, `ruff check --isolated
+--select <code>` was run against both files after the move.
+
+| File | Entry | Note |
+|---|---|---|
+| `src/pdsfile/pdsfile.py` | unchanged | every one of its 23 codes is still triggered by lines that stayed, so none could be dropped |
+| `src/pdsfile/_path_utils.py` | `["E701", "F841"]` | the only two codes the moved lines trigger |
+
+Both new-entry codes are already in `pdsfile.py`'s entry, so this is a **split of
+an existing entry, not a new suppression**: E701 was 16 instances in the parent's
+`pdsfile.py` and is now 14 + 2, F841 was 7 and is now 6 + 1. The count of
+distinct (file, code) suppressions rises by two while the number of suppressed
+violations is unchanged; no code that was not already forgiven for these lines is
+forgiven now. Had `_path_utils.py` needed a code absent from `pdsfile.py`'s
+entry, that would have been a §6.4 hard stop.
+
+### 8. Consumer smoke — outcome unchanged
+
+`critiques/baselines/consumer-smoke-baseline.md` calls out this PR by name: it
+records rms-viewmaster reaching `pdsfile.pdsfile.repair_case` at
+`pdsiterator.py:104` and says "Phase 5 moves module-level functions into private
+modules while `pdsfile/pdsfile.py` keeps re-exporting every name it exports today
+— `repair_case` is one of the names that re-export must preserve, and this
+baseline is where a regression would show up." Both checks were re-run. The gate
+is **same outcome as baseline**, not "passes".
+
+| Check | Baseline | This branch |
+|---|---|---|
+| A — rms-opus import paths | 4/4 resolve, 0 failures | **4/4 resolve, 0 failures** |
+| B — rms-viewmaster startup | 5 ok, 3 pre-existing failures | **5 ok, 3 failures — the same three** |
+
+The three Check-B failures are still `pdsfile.cache_lifetime` (raises),
+`pdsfile.DEFAULT_CACHING` (absent, so viewmaster's assignment stays a silent
+no-op) and the same `cache_lifetime` read inside `get_page_cache()`. None became
+a pass. **`pdsfile.pdsfile.repair_case` still resolves.**
+
+Environment note carried from the baseline: the check ran under the pdsfile
+venv's interpreter with rms-viewmaster's `site-packages` appended to
+`PYTHONPATH`, because that venv lacks pdsfile's declared `range_ex` dependency.
+rms-viewmaster is at `a0d05e2` with the same three untracked entries the baseline
+records.
+
+### 9. Clean install
+
+`scripts/clean_install_check.sh` passes. The new module is picked up by the
+existing `include = ["pdsfile*"]` package glob with no packaging change: the
+built wheel contains `pdsfile/_path_utils.py`, and the gate imports the whole
+manifest module surface — `pdsfile.pdsfile` among them — which cannot succeed if
+`_path_utils.py` is missing from the distribution.
+
+### 10. Deferred observations
+
+**None.** This PR moves code without changing it, so it surfaced no new defect;
+no existing entry in `critiques/deferred-observations.md` is resolved or
+invalidated by it, and none of entries 1–28 owns a symbol it touches.
+
+### 11. Review loop
+

--- a/critiques/phase5-validation.md
+++ b/critiques/phase5-validation.md
@@ -603,7 +603,7 @@ restyled to dodge an inherited lint violation — that is PR-23's job.
 `pdsfile.pdsfile.X is pdsfile._path_utils.X` for all twelve re-exported names, so
 callers get the same objects, not copies.
 
-`pdsfile.py`: 6,308 → 6,122 lines; `_path_utils.py`: 219 lines.
+`pdsfile.py`: 6,308 → 6,125 lines; `_path_utils.py`: 219 lines.
 
 ### 6. Keeping `pdsfile.pdsfile.X` resolving without touching the ratchet
 
@@ -705,3 +705,25 @@ them owns a symbol it touches.
 
 ### 11. Review loop
 
+| Round | Verdict | Findings | Record |
+|---|---|---|---|
+| 1 | goal **not** met | **1 Major**, 4 Minor, 2 Deferred — all nine accepted and fixed, none rebutted | `critiques/pr-16/round-1.md` |
+| 2 | goal met | 0 Major, 5 Minor (4 accepted and fixed, 1 rebutted), 3 Deferred (2 new entries) | `critiques/pr-16/round-2.md` |
+
+Round 1's Major is the one worth carrying forward: the moved code was
+byte-perfect and every *call site* resolved, but a test **patched** the namespace
+the moved function used to resolve through, so it silently stopped exercising the
+code it was written for while still passing. The §6.2 set diff cannot see that
+class of defect, which is what the adversarial round is for. Deferred entry 29
+turns it into a step for PR-17 onward.
+
+Round 1's fixes touched `src/pdsfile/pdsfile.py`, so the full-data record was
+regenerated before round 2 (§6.6 step 5) — both trees, both modes, after commit
+`37d4246`. Later rounds changed only `plans/` and `critiques/`, which under that
+same rule does not stale the record, so the runs recorded in §3 carry forward
+unchanged.
+
+The one rebuttal is round 2's "the PR does not exist yet": §6.6 runs the loop
+**before** the PR is opened ("Termination — … Then open the PR"), so a reviewer
+cannot see the PR description at review time by construction. It is recorded in
+`critiques/pr-16/round-2.md` rather than actioned.

--- a/critiques/phase5-validation.md
+++ b/critiques/phase5-validation.md
@@ -695,7 +695,7 @@ manifest module surface — `pdsfile.pdsfile` among them — which cannot succee
 
 ### 10. Deferred observations
 
-Four new entries in `critiques/deferred-observations.md`, all raised by the
+Six new entries in `critiques/deferred-observations.md`, all raised by the
 review loop and all out of scope for a pure move:
 
 | # | Observation | Raised in | Owner |
@@ -704,6 +704,8 @@ review loop and all out of scope for a pure move:
 | 30 | `repair_case` raises `UnboundLocalError` on a single-component path | round 1 | PR-23 |
 | 31 | `src/pdsfile/__init__.py`'s `from pdsfile import *` is a self-import that binds nothing, and is not simply fixable | round 2 | PR-24 |
 | 32 | A commented-out line rode along in the byte-for-byte move, so PR-22's dead-code line list must be rebuilt against the post-Phase-5 module set | round 2 | PR-22 |
+| 33 | `scripts/gen_ruff_ratchet.py` emits an empty block against the current tree, so the ratchet-regeneration workflow PR-23/PR-24 depend on cannot be exercised as documented | round 4 | PR-23 |
+| 34 | Six pre-existing tracked files carry multi-component fragments of the real holdings roots (no complete root); one is a test module | round 4 | owner, then PR-24 / PR-36 |
 
 No entry in the existing 1–28 is resolved or invalidated by this PR, and none of
 them owns a symbol it touches.
@@ -715,6 +717,7 @@ them owns a symbol it touches.
 | 1 | goal **not** met | **1 Major**, 4 Minor, 2 Deferred — the Major and all four Minor accepted and fixed, none rebutted | `critiques/pr-16/round-1.md` |
 | 2 | goal met | 0 Major, 5 Minor (4 accepted and fixed, 1 rebutted), 3 Deferred (2 new entries) | `critiques/pr-16/round-2.md` |
 | 3 | goal met | 0 Major, 6 Minor (all accepted and fixed, none rebutted), 2 Deferred (one folded into entry 29) | `critiques/pr-16/round-3.md` |
+| 4 | goal met | **0 new Major**; the scoped re-review confirmed 15 of 16 prior findings resolved and the one rebuttal sound, and raised 1 incompletely-resolved Minor plus 2 non-blocking notes, all fixed | `critiques/pr-16/round-4.md` |
 
 Round 1's Major is the one worth carrying forward: the moved code was
 byte-perfect and every *call site* resolved, but a test **patched** the namespace
@@ -723,11 +726,13 @@ code it was written for while still passing. The §6.2 set diff cannot see that
 class of defect, which is what the adversarial round is for. Deferred entry 29
 turns it into a step for PR-17 onward.
 
-Round 1's fixes touched `src/pdsfile/pdsfile.py`, so the full-data record was
-regenerated before round 2 (§6.6 step 5) — both trees, both modes, after commit
-`37d4246`. Later rounds changed only `plans/` and `critiques/`, which under that
-same rule does not stale the record, so the runs recorded in §3 carry forward
-unchanged.
+Two rounds touched `src/pdsfile/`, and under §6.6 step 5 each forced a
+regeneration before the next reviewer. Round 1's fix (`37d4246`) regenerated both
+trees, both modes. Round 3's fix (`b86adba` — a comment line in `_path_utils.py`)
+regenerated the **head** side only, the baseline worktree being a detached tree at
+`1a5d85c` that no round has touched; §3 records the runs from that second
+regeneration. Round 2 changed only `plans/` and `critiques/`, which under the same
+rule does not stale the record.
 
 The one rebuttal is round 2's "the PR does not exist yet": §6.6 runs the loop
 **before** the PR is opened ("Termination — … Then open the PR"), so a reviewer

--- a/critiques/phase5-validation.md
+++ b/critiques/phase5-validation.md
@@ -440,9 +440,12 @@ than copied from the table, exactly as PR-15 re-measured `rewrite`'s. The
 re-measurement reproduced §3b exactly.
 **Date:** 2026-07-27
 **Sub-plan:** [`plans/2026-07-27-pr-16-subplan.md`](../plans/2026-07-27-pr-16-subplan.md)
-**Last change under `src/pdsfile/`:** commit `37d4246` (the round-1 fix), at
-01:18:32. Every run recorded below was regenerated after it, per §6.6 step 5 —
-the four `--junitxml` timestamps are 01:19:13, 01:22:05, 01:24:02 and 01:26:51.
+**Last change under `src/pdsfile/`:** commit `b86adba` (the round-3 fix — a
+comment line in `_path_utils.py`), at 02:02:17. The **head** runs recorded below
+were regenerated after it, per §6.6 step 5: their `--junitxml` timestamps are
+02:02:25 and 02:05:15. The **baseline** runs (01:19:13 and 01:22:05) stand: they
+were taken in a detached worktree at `1a5d85c` that no round has touched, so
+re-running them would measure the same unchanged tree.
 
 This PR is a pure extraction. Unlike PR-15 it has **no licence to move the
 pass/fail set in either direction**, so the gate here is simply "the two set

--- a/critiques/phase5-validation.md
+++ b/critiques/phase5-validation.md
@@ -478,7 +478,7 @@ been measured there too.
 |---|---|
 | API-freeze manifest test | **passed**; and the dumped surface is byte-identical to the parent's — §4 |
 | Full-data suite, both modes | **passed** — both set diffs empty; §3 |
-| `ruff check src/pdsfile tests scripts` | **passed**; the ratchet gained no code — §5 |
+| `ruff check src/pdsfile tests scripts` | **passed**; the ratchet gained no code — §7 |
 | Clean-install import check | **passed** (throwaway venv, `pip install .`, full module surface imports) |
 | Hosted lint/no-holdings job (`scripts/run-all-checks.sh`, no holdings env vars) | **passed**, 59 passed / 800 skipped — identical to PR-15's §4 |
 | Adversarial review loop | `critiques/pr-16/round-<k>.md` |
@@ -511,7 +511,7 @@ against PR-15's baseline rather than against a fresh unrelated measurement.
 
 The manifest records `pdsfile.pdsfile`'s module-level names including imported
 modules, so this gate is stricter here than it looks: dropping the now-unreferenced
-`import glob` / `import math` would have been a manifest break. See §5.
+`import glob` / `import math` would have been a manifest break. See §6.
 
 `pdsfile._path_utils` is underscore-prefixed, so the dumper skips it where the
 submodule import binds it onto the `pdsfile` package — which is exactly the
@@ -692,13 +692,15 @@ manifest module surface — `pdsfile.pdsfile` among them — which cannot succee
 
 ### 10. Deferred observations
 
-Two new entries in `critiques/deferred-observations.md`, both raised by the
-review loop and both out of scope for a pure move:
+Four new entries in `critiques/deferred-observations.md`, all raised by the
+review loop and all out of scope for a pure move:
 
-| # | Observation |
-|---|---|
-| 29 | An extraction sweep must also ask which module namespaces the tests *patch*, not only which globals the code *reads* — the direction that produced this PR's one Major |
-| 30 | `repair_case` raises `UnboundLocalError` on a single-component path |
+| # | Observation | Raised in | Owner |
+|---|---|---|---|
+| 29 | An extraction sweep must also ask which module namespaces the tests *patch* — and which module-level *data* they rebind — not only which globals the code *reads*. The first half is the direction that produced this PR's one Major | round 1 (+ round 3) | PR-17 onward |
+| 30 | `repair_case` raises `UnboundLocalError` on a single-component path | round 1 | PR-23 |
+| 31 | `src/pdsfile/__init__.py`'s `from pdsfile import *` is a self-import that binds nothing, and is not simply fixable | round 2 | PR-24 |
+| 32 | A commented-out line rode along in the byte-for-byte move, so PR-22's dead-code line list must be rebuilt against the post-Phase-5 module set | round 2 | PR-22 |
 
 No entry in the existing 1–28 is resolved or invalidated by this PR, and none of
 them owns a symbol it touches.
@@ -707,8 +709,9 @@ them owns a symbol it touches.
 
 | Round | Verdict | Findings | Record |
 |---|---|---|---|
-| 1 | goal **not** met | **1 Major**, 4 Minor, 2 Deferred — all nine accepted and fixed, none rebutted | `critiques/pr-16/round-1.md` |
+| 1 | goal **not** met | **1 Major**, 4 Minor, 2 Deferred — the Major and all four Minor accepted and fixed, none rebutted | `critiques/pr-16/round-1.md` |
 | 2 | goal met | 0 Major, 5 Minor (4 accepted and fixed, 1 rebutted), 3 Deferred (2 new entries) | `critiques/pr-16/round-2.md` |
+| 3 | goal met | 0 Major, 6 Minor (all accepted and fixed, none rebutted), 2 Deferred (one folded into entry 29) | `critiques/pr-16/round-3.md` |
 
 Round 1's Major is the one worth carrying forward: the moved code was
 byte-perfect and every *call site* resolved, but a test **patched** the namespace

--- a/critiques/phase5-validation.md
+++ b/critiques/phase5-validation.md
@@ -440,8 +440,9 @@ than copied from the table, exactly as PR-15 re-measured `rewrite`'s. The
 re-measurement reproduced §3b exactly.
 **Date:** 2026-07-27
 **Sub-plan:** [`plans/2026-07-27-pr-16-subplan.md`](../plans/2026-07-27-pr-16-subplan.md)
-**Last change under `src/pdsfile/`:** the extraction commit. Every run recorded
-below was generated after it.
+**Last change under `src/pdsfile/`:** commit `37d4246` (the round-1 fix), at
+01:18:32. Every run recorded below was regenerated after it, per §6.6 step 5 —
+the four `--junitxml` timestamps are 01:19:13, 01:22:05, 01:24:02 and 01:26:51.
 
 This PR is a pure extraction. Unlike PR-15 it has **no licence to move the
 pass/fail set in either direction**, so the gate here is simply "the two set
@@ -453,8 +454,23 @@ diffs are empty", and the section is correspondingly short.
 |---|---|
 | Interpreter | CPython 3.12.3, repo venv, `pip install -e ".[dev]"` |
 | Holdings | `PDS3_HOLDINGS_DIR` / `PDS4_HOLDINGS_DIR` + `PDSFILE_TEST_HOLDINGS=full`, pointed at the limited testing copy the goldens are tuned to |
-| Baseline tree | `git worktree` at the parent tip `1a5d85c`, same interpreter, same holdings |
+| Baseline tree | a `git worktree` detached at the parent tip `1a5d85c`, same interpreter, same holdings; `pytest` reports that directory as `rootdir` |
 | Command lines | exactly those in `scripts/automated_tests/pdsfile_main_test.sh` (serial, under `coverage`), plus `-rA --junitxml` |
+
+**Which source each run actually imported, proved rather than assumed.** The
+interpreter is the main tree's venv, whose editable install puts
+`<main tree>/src` on `sys.path`, so a worktree run could silently measure the
+wrong tree and make the whole comparison vacuous. After each pair of passes,
+`coverage.CoverageData.measured_files()` was read for its **absolute** paths:
+
+| Run | pdsfile modules measured |
+|---|---|
+| baseline | `<worktree>/src/pdsfile/pdsfile.py` — and no `_path_utils.py`, because that file does not exist at `1a5d85c` |
+| this branch | `<main tree>/src/pdsfile/pdsfile.py` **and** `<main tree>/src/pdsfile/_path_utils.py` |
+
+The absence of `_path_utils.py` on the baseline side is the decisive bit: had the
+worktree run leaked into the main tree's install, the extracted module would have
+been measured there too.
 
 ### 2. Active §2 gates
 
@@ -531,12 +547,45 @@ can check it" case the plan's sweep requirement exists for: `_GLOB_CACHE_SIZE`
 appears **only** in `@functools.lru_cache(maxsize=_GLOB_CACHE_SIZE)`, so a
 body-only sweep reports it as unreferenced and the extracted module raises
 `NameError` at import. The plan's brief names `FILE_BYTE_UNITS` alone; the sweep
-found the second one. `_GLOB_CACHE_SIZE` is private, has no other reference
-anywhere in the tree, and is therefore **not** re-exported; `FILE_BYTE_UNITS` is
-public and is.
+found the second one. Both are re-exported: `FILE_BYTE_UNITS` because it is
+public and frozen, `_GLOB_CACHE_SIZE` because the Phase-5 preamble's rule is
+"`pdsfile.py` keeps re-exporting every name it exports today" without a
+public/private qualifier, and carrying it costs one line and keeps the invariant
+below exact.
+
+**Zero names lost, measured.** `sorted(vars(pdsfile.pdsfile))` was compared
+between the parent worktree and this branch: **45 names on each side, none lost
+and none gained.** That is a stronger statement than the manifest makes (the
+manifest skips underscore names) and it is the simplest form of the preamble's
+"`pdsfile.pdsfile.X` access is unchanged".
 
 `PATH_EXISTS_CACHE_SIZE` was left alone — its consumer is the `lru_cache` on
 `os_path_exists`, which moves with `_local_fs.py` in PR-17.
+
+**The sweep's second direction: who *patches* these globals.** The free-variable
+sweep answers "what must move with the code"; it does not answer "does anything
+outside `src/` rebind one of these names on the old module". That second grep
+(`monkeypatch.setattr` / `setattr(<module>` over `tests/` and `scripts/`) finds
+three sites repo-wide, of which exactly one was affected:
+`tests/core/test_pdsfile_path_resolution.py` replaced `glob` on
+`pdsfile.pdsfile`, which `abspath_for_logical_path` no longer resolves through.
+The test still *passed* after the move — an outcome-set diff is structurally
+blind to a test that has stopped testing — but only because this machine has no
+`/Library/WebServer/Documents/holdings*`. It now patches
+`abspath_for_logical_path.__globals__` instead, which follows the function
+wherever later PRs move it. Proved by making the real `glob.glob` return a hit,
+i.e. simulating the MacOS install the branch exists for:
+
+| stub site | result with `glob.glob` returning a hit |
+|---|---|
+| none | resolves to the stub root — the test would fail |
+| `pdsfile.pdsfile.glob` (the old site) | resolves to the stub root — the test would fail |
+| `abspath_for_logical_path.__globals__` (the new site) | `ValueError: No holdings directory` — the test passes for the right reason |
+
+The other two patch sites are unaffected: one rebinds `PdsFile` class attributes,
+the other rebinds a name on `pdsviewable`, which this PR does not touch. This
+reverse direction is worth adding to PR-17's sweep, where `os` is the analogous
+name (deferred entry 29).
 
 **No import cycle:** `_path_utils.py`'s module-level imports are `fnmatch`,
 `functools`, `glob`, `math`, `os` and nothing else — verified by parsing the
@@ -551,35 +600,48 @@ functions and both constants identical. The contiguous run from the first moved
 additionally rules out a reordering or a dropped blank line. No moved body was
 restyled to dodge an inherited lint violation — that is PR-23's job.
 
-`pdsfile.pdsfile.X is pdsfile._path_utils.X` for all eleven re-exported names,
-so callers get the same objects, not copies.
+`pdsfile.pdsfile.X is pdsfile._path_utils.X` for all twelve re-exported names, so
+callers get the same objects, not copies.
 
 `pdsfile.py`: 6,308 → 6,122 lines; `_path_utils.py`: 219 lines.
 
 ### 6. Keeping `pdsfile.pdsfile.X` resolving without touching the ratchet
 
-Four names in `pdsfile.py` are now referenced nowhere in it but are frozen
-members of its public surface: `FILE_BYTE_UNITS`, `selected_path_from_path`,
-`glob` and `math`. Measured rather than assumed — rewriting the four statements
-in plain form and re-running `ruff` produces exactly four F401s and no others:
+Five names in `pdsfile.py` are now referenced nowhere in it but must stay bound:
+`glob`, `math`, `FILE_BYTE_UNITS` and `selected_path_from_path` are frozen
+members of its public surface, and `_GLOB_CACHE_SIZE` is carried for the
+zero-names-lost invariant in §5. Measured rather than assumed — rewriting the
+five statements in plain form and re-running `ruff` produces exactly five F401s
+and no others:
 
 ```
 F401 `glob` imported but unused
 F401 `math` imported but unused
 F401 `._path_utils.FILE_BYTE_UNITS` imported but unused
+F401 `._path_utils._GLOB_CACHE_SIZE` imported but unused
 F401 `._path_utils.selected_path_from_path` imported but unused
 ```
 
 `pdsfile.py`'s ratchet entry does not contain F401, and the ratchet header in
-`pyproject.toml` forbids both growing it and adding an inline `noqa`. All four
+`pyproject.toml` forbids both growing it and adding an inline `noqa`. All five
 therefore use the PEP-484 redundant-alias form (`import glob as glob`,
 `FILE_BYTE_UNITS as FILE_BYTE_UNITS`), which ruff recognises as an explicit
 re-export. `pdsfile.py` now reports **0** F401 with no suppression of any kind.
 
 ### 7. Ruff ratchet — no code gained
 
-Procedure: for every code in `pdsfile.py`'s entry, `ruff check --isolated
---select <code>` was run against both files after the move.
+Procedure: for every code in `pdsfile.py`'s entry, the following was run against
+both files after the move —
+
+```
+ruff check --no-cache --isolated --select <code> \
+           --line-length 100 --target-version py310 <file>
+```
+
+`--isolated` drops `pyproject.toml`'s `line-length = 100` and would otherwise
+report an E501 at 88 columns that the project config does not, so the two
+settings are restored explicitly. Reproducing the counts below requires that
+exact command.
 
 | File | Entry | Note |
 |---|---|---|
@@ -630,9 +692,16 @@ manifest module surface — `pdsfile.pdsfile` among them — which cannot succee
 
 ### 10. Deferred observations
 
-**None.** This PR moves code without changing it, so it surfaced no new defect;
-no existing entry in `critiques/deferred-observations.md` is resolved or
-invalidated by it, and none of entries 1–28 owns a symbol it touches.
+Two new entries in `critiques/deferred-observations.md`, both raised by the
+review loop and both out of scope for a pure move:
+
+| # | Observation |
+|---|---|
+| 29 | An extraction sweep must also ask which module namespaces the tests *patch*, not only which globals the code *reads* — the direction that produced this PR's one Major |
+| 30 | `repair_case` raises `UnboundLocalError` on a single-component path |
+
+No entry in the existing 1–28 is resolved or invalidated by this PR, and none of
+them owns a symbol it touches.
 
 ### 11. Review loop
 

--- a/critiques/pr-16/round-1.md
+++ b/critiques/pr-16/round-1.md
@@ -1,0 +1,141 @@
+# PR-16 — adversarial review round 1
+
+**Date:** 2026-07-27
+**Reviewer:** a fresh, no-context opus-class subagent (§6.6 step 2), given only
+the PR-16 section of the plan, the Phase-5 preamble, §2 ground rules, §6.1/§6.2,
+the §6.6 rules including the progressive `.cursor/rules` schedule, the exact
+`git diff origin/pr-15-latent-bug-fixes...HEAD`, and read access to the repo at
+HEAD, to the consumer repos and to the real holdings. It was told explicitly that
+the PR is stacked and that PR-15's changes are out of scope.
+**Diff reviewed:** `origin/pr-15-latent-bug-fixes`(`1a5d85c`)`...HEAD`(`3df19d9`)
+**Verdict: goal not met** — **1 Major**, 4 Minor, 2 Deferred.
+
+## What the reviewer independently re-ran
+
+Not a paper review: it reproduced the gate evidence rather than reading it off
+the record.
+
+| Check | Reviewer's result |
+|---|---|
+| Byte-for-byte move (its own AST extraction, both trees) | all 10 functions + `FILE_BYTE_UNITS` + `_GLOB_CACHE_SIZE` identical |
+| The constant sweep, re-implemented from scratch | reproduced the record's table exactly, including the decorator pass |
+| `dump_public_api.py`, both trees via `git archive` | byte-identical, 733,876 bytes each; freeze test passes; the four prohibited files untouched |
+| Full-data evidence — re-derived both outcome sets from the raw junit XML with its own reduction script | ns 859 ids, s 558 ids, sets identical on both sides, matching PR-15 §3b |
+| Record staleness (junit timestamps vs commit and file mtimes) | runs postdate the last `src/pdsfile/` change |
+| Ruff ratchet, every code in `pdsfile.py`'s entry, under the **project** config | parent E701×16 / F841×7 → head 14+2 / 6+1; totals identical, no code droppable |
+| F401 / re-export form; `glob` and `math` present in the manifest as `module` | 0 hits, no `noqa`; keeping them bound was required |
+| Runtime identity of all re-exported names; a legacy pickle of `pdsfile.pdsfile repair_case` | same objects; pickle still loads |
+| Confidentiality grep over all six changed files | clean |
+| Consumer smoke A and the three known B failures | same outcome as baseline |
+| Packaging (`include = ["pdsfile*"]`), LF, trailing newline | clean |
+
+## Findings
+
+### Major 1 — a reference to the moved code's namespace was not updated
+
+`tests/core/test_pdsfile_path_resolution.py:91` patched `glob` on
+`pdsfile.pdsfile`, the module `abspath_for_logical_path` used to live in. After
+the move the function resolves `glob` through `pdsfile._path_utils`, so the stub
+reached nothing and the last-resort MacOS branch ran against the real
+filesystem. The test still passed — on this machine, and only because
+`/Library/WebServer/Documents/holdings*` does not exist here. On the platform
+that branch exists for it would fail, and the module is marked
+`holdings_free` with a docstring promising it reads no real tree.
+
+The reviewer measured it both ways and noted why §6.2 could not catch it: an
+outcome-set diff compares pass/fail, so it is structurally blind to a test that
+has stopped testing.
+
+**Accepted and fixed** (`37d4246`). The patch now targets
+`abspath_for_logical_path.__globals__` — the namespace the function itself
+resolves through, whichever module that is — so it stays attached when PR-17 and
+later PRs move code again. The now-unused `pdsfile_module` import was dropped.
+
+Verified by simulating the machine the branch exists for, i.e. making the real
+`glob.glob` return a hit:
+
+| stub site | result |
+|---|---|
+| none | resolves to the stub root — the test would fail |
+| `pdsfile.pdsfile.glob` (the old site) | resolves to the stub root — the test would fail |
+| `abspath_for_logical_path.__globals__` (the new site) | `ValueError: No holdings directory` — passes for the right reason |
+
+The general lesson — an extraction sweep must ask who *patches* a moved module's
+globals, not only which globals the code *reads* — is recorded as deferred entry
+29, since it applies to every later extraction PR.
+
+### Minor 2 — comments narrated the change instead of stating current state, and one carried a PR number
+
+`pyproject.toml` ("Split off pdsfile.py's entry … PR-23 is where they get
+fixed"), `src/pdsfile/pdsfile.py:10` ("Nothing below references glob or math
+**any more**") and `:42` ("Path helpers, **extracted to** a private module"). The
+reviewer noted that `grep -rn "PR-[0-9]"` over the source and config returned
+exactly the one new line, so there was no precedent to lean on.
+
+**Accepted and fixed** (`37d4246`): all three restated as standing facts, PR
+reference removed.
+
+### Minor 3 — the record's ruff procedure did not reproduce its own result
+
+The record said `ruff check --isolated --select <code>`. `--isolated` drops
+`line-length = 100`, so re-running it as written reports a third code (E501 at 88
+columns) for the new module. The committed entry is nonetheless correct: under
+the project config the file triggers exactly E701×2 and F841×1.
+
+**Accepted and fixed**: §7 of the record now gives the exact command including
+`--line-length 100 --target-version py310`, and says why.
+
+### Minor 4 — the record claimed a provenance the baseline runs did not have
+
+The Environment table said the baseline was measured in a `git worktree` at
+`1a5d85c`, and the preamble said every run postdated the extraction commit. Both
+were false for the two baseline runs: they were made in the main tree at
+`e955a22` (a doc-only descendant whose `src/` is byte-identical to `1a5d85c`)
+*before* the extraction. The measurement was sound; the description was not.
+
+**Accepted, and fixed by re-measuring rather than by rewording.** Both baseline
+passes were re-run inside the worktree, and both head passes were re-run after
+the round-1 fix, so the record's provenance is now literally true. The re-run
+also added something the first pass lacked: `coverage.CoverageData.measured_files()`
+is now dumped after each pair of passes, so the record *proves* which tree's
+source each run imported — the baseline measured the worktree's `pdsfile.py` and
+no `_path_utils.py` (that file does not exist at `1a5d85c`), the head runs
+measured the main tree's `pdsfile.py` **and** `_path_utils.py`. Without that, a
+worktree run leaking into the main tree's editable install would have made the
+whole comparison vacuous. Both set diffs are still empty.
+
+### Minor 5 — `pdsfile.pdsfile._GLOB_CACHE_SIZE` stopped resolving
+
+The one name lost from `pdsfile.pdsfile`'s namespace. Nothing breaks — it is
+private, absent from the manifest and from the consumer baseline, and has no
+other reference in the tree — but the Phase-5 preamble's re-export rule is
+written without a public/private qualifier, and the record had resolved that
+tension on the executor's own authority.
+
+**Accepted and fixed** (`37d4246`) by taking the preamble literally: it is
+carried in the re-export block. That is one line, freeze-invisible either way,
+and it upgrades the claim to a checkable invariant — `sorted(vars(pdsfile.pdsfile))`
+is now **45 names on each side, none lost and none gained**. The alternative the
+reviewer offered (getting the qualifier written into the preamble) would have
+been a plan change and therefore a §6.4 hard stop; this avoids it.
+
+## Deferred (recorded, not fixed)
+
+| # | Item |
+|---|---|
+| 29 | An extraction sweep must also ask which module namespaces the tests *patch* — the direction that produced Major 1. Owner: PR-17 onward |
+| 30 | `repair_case` raises `UnboundLocalError` on a single-component path (`repair_case('/', Pds3File)`). Pre-existing, moved byte-for-byte, outside PR-15's enumerated list. Owner: PR-23 or whichever PR next edits the file |
+
+Both appended to `critiques/deferred-observations.md`.
+
+## Rebuttals
+
+**None.** All five findings were accepted and fixed.
+
+## Regeneration
+
+The round's fixes touched `src/pdsfile/pdsfile.py`, so under §6.6 step 5 the
+full-data record was regenerated before the next reviewer: both modes on both
+trees, after commit `37d4246`. Both set diffs are empty; the API dump is still
+byte-identical; `ruff` is clean; the no-holdings run is still 59 passed / 800
+skipped; consumer smoke is still 4/4 and 5 ok / the same 3 failures.

--- a/critiques/pr-16/round-2.md
+++ b/critiques/pr-16/round-2.md
@@ -23,7 +23,7 @@ same brief as round 1 and explicitly told not to read the round-1 record.
 | Ratchet, per code, under the project config | E701 16 → 14+2, F841 7 → 6+1; `_path_utils.py` triggers exactly those two; `pdsfile.py`'s 23 codes all still triggered, so its entry could not shrink; no inline `noqa` in the diff |
 | Holdings-free run; `pytest tests/core/ tests/api/` | 59 passed / 800 skipped; 36 passed |
 | Sub-plan precedence (§6.4 step 1) | `e955a22` 00:45:52 precedes the code commit `a5d2321` 00:54:38 |
-| Confidentiality — the real root values, `/home/rfrench`, `Shared-OPUS`, `/seti/opus` grepped against every file this PR adds | clean |
+| Confidentiality — the values of `$PDS3_HOLDINGS_DIR` / `$PDS4_HOLDINGS_DIR` and their distinctive path components, grepped against every file this PR adds | clean, no literal root anywhere |
 | The round-1 test fix | `abspath_for_logical_path.__globals__` **is** `_path_utils.__dict__`; `monkeypatch.setitem` restores it; the removed import has no remaining references |
 
 ## Findings

--- a/critiques/pr-16/round-2.md
+++ b/critiques/pr-16/round-2.md
@@ -1,0 +1,114 @@
+# PR-16 — adversarial review round 2
+
+**Date:** 2026-07-27
+**Reviewer:** a fresh, no-context opus-class subagent (§6.6 step 5), given the
+same brief as round 1 and explicitly told not to read the round-1 record.
+**Diff reviewed:** `origin/pr-15-latent-bug-fixes`(`1a5d85c`)`...HEAD`(`7e44938`)
+**Verdict: goal met** — 0 Major, 5 Minor (4 accepted and fixed, 1 rebutted),
+3 Deferred.
+
+## What the reviewer independently re-ran
+
+| Check | Reviewer's result |
+|---|---|
+| Moved block, parent lines 47–247 vs `_path_utils.py` lines 19–219 | identical, `md5 9f41eed24bffb48918ea7f33b96fc386` on both sides |
+| **The rest of `pdsfile.py`** — parent :253–6308 vs HEAD :70–6125 | identical, `md5 e0e6fdee5f64ed8ae6135e188149e7f5`; the only other edits are the import block and the deleted region |
+| Repo-wide grep for all twelve moved names, every call site resolved | in-package callers via the plain import, external callers (`COVIMS_0xxx.py:6`, `test_pds3file_blackbox.py:4-6`, `pdsfile_test_helper.py:8`) via the re-export |
+| `pdsfile.pdsfile.X is pdsfile._path_utils.X`; `sorted(vars(pdsfile.pdsfile))` | same objects for all twelve; 45 names, identical to the parent's list |
+| The sweep, re-derived | `_GLOB_CACHE_SIZE` reachable only through the decorator argument and correctly moved; `PATH_EXISTS_CACHE_SIZE`'s only consumer stayed; `HAS_PYLIBMC` referenced by no moved symbol; `_path_utils.py` stdlib-only, no cycle |
+| `dump_public_api.py` on a parent worktree and on HEAD | 733,876 bytes each, byte-identical; the delta vs the committed manifest is confined to §6.1 forgiveness category (2) and is **identical on both sides**, so it is pre-existing |
+| The four prohibited files | untouched (numstat) |
+| Full-data evidence: junit timestamps vs `37d4246`; its own reduction of the four XMLs | all four runs postdate the last `src/pdsfile/` change; parent-ns 825/34/859 = head-ns, parent-s 555/3/558 = head-s, **both diffs empty id-by-id**, and its recomputation matches the committed `.set` files |
+| That the comparison is not vacuous | probed that the baseline worktree at `1a5d85c` imports `<worktree>/src/pdsfile/pdsfile.py`, not the editable install |
+| Ratchet, per code, under the project config | E701 16 → 14+2, F841 7 → 6+1; `_path_utils.py` triggers exactly those two; `pdsfile.py`'s 23 codes all still triggered, so its entry could not shrink; no inline `noqa` in the diff |
+| Holdings-free run; `pytest tests/core/ tests/api/` | 59 passed / 800 skipped; 36 passed |
+| Sub-plan precedence (§6.4 step 1) | `e955a22` 00:45:52 precedes the code commit `a5d2321` 00:54:38 |
+| Confidentiality — the real root values, `/home/rfrench`, `Shared-OPUS`, `/seti/opus` grepped against every file this PR adds | clean |
+| The round-1 test fix | `abspath_for_logical_path.__globals__` **is** `_path_utils.__dict__`; `monkeypatch.setitem` restores it; the removed import has no remaining references |
+
+## Findings
+
+### Major
+
+**None.**
+
+### Minor 1 — §11 of the validation record was an empty heading
+
+**Accepted and fixed:** the round table is filled, in the shape PR-15's §12 uses,
+with the regeneration note and the one rebuttal.
+
+### Minor 2 — a stale line count
+
+`critiques/phase5-validation.md` said "`pdsfile.py`: 6,308 → 6,122 lines". 6,122
+was right at `3df19d9`; the round-1 fix added three lines. The reviewer noted
+that every other figure in the section re-measured correctly.
+
+**Accepted and fixed:** 6,308 → **6,125**, re-measured.
+
+### Minor 3 — the sub-plan contradicts the delivered code in four places
+
+`plans/2026-07-27-pr-16-subplan.md` still said `_GLOB_CACHE_SIZE` is "not
+re-exported", that the extraction commit is "the only commit that touches
+`src/pdsfile/`", that "nothing else in the PR touches `src/`", and that the PR
+has "no test change" — all made false by the round-1 fix.
+
+**Accepted and fixed by appending an "as executed" section (§8) rather than
+editing §1–§7.** The sub-plan's purpose under §6.4 is to be the thing that was
+decided *before* the mechanical work; silently rewriting it to match the outcome
+would destroy exactly the evidence it exists to provide. §8 lists each divergence
+and why it happened.
+
+### Minor 4 — the sub-plan's verification check 9 is unsatisfiable as worded
+
+"`import pdsfile._path_utils` as the first pdsfile import → imports without
+touching `pdsfile.pdsfile`" cannot hold: importing any submodule runs
+`pdsfile/__init__.py`, which star-imports `.pds3file`, which imports
+`pdsfile.pdsfile`. The reviewer measured `'pdsfile.pdsfile' in sys.modules` as
+True and correctly noted that nothing false was *recorded* — the validation
+record never claims check 9's result, and states instead what was actually
+verified.
+
+**Accepted and fixed** in the same §8: the check is restated as "`_path_utils`'s
+module-level imports are stdlib-only and it contains no
+`from pdsfile.pdsfile import`", which is what §5 of the record verifies by
+parsing the module. A fifth item was added in the same pass: §5 of the sub-plan
+gave the ruff command without `--line-length 100`, the same imprecision round 1
+found in the record.
+
+### Minor 5 — "the PR does not exist yet" — **rebutted**
+
+The reviewer observed that `pr-16-path-utils` is unpushed and no PR exists, so
+`pull_request.mdc` compliance and the description's path-cleanliness cannot be
+verified.
+
+**Rebuttal:** this is the plan's own sequencing, not an omission. §6.6 states
+that the loop runs *before* the PR is opened — "Termination — the loop ends when
+a fresh reviewer returns zero Major findings and no *new, un-rebutted* Minor
+findings (verdict `goal met`). **Then open the PR.**" A reviewer therefore cannot
+see the PR description at review time by construction, in this PR or any other.
+Acting on the finding would mean opening the PR before the loop converges, which
+inverts the protocol. The substance the reviewer could check — that no absolute
+holdings path appears in any committed file — it did check, and found clean; the
+description reuses those same committed figures and names the holdings roots only
+by their environment variables.
+
+Recorded rather than actioned. Per §6.6's anti-thrash rules a re-raised Minor
+that was reasonably rebutted does not escalate.
+
+## Deferred (recorded, not fixed)
+
+| # | Item |
+|---|---|
+| 31 | `src/pdsfile/__init__.py:10`'s `from pdsfile import *` is a self-import that binds nothing. Reproduced in a throwaway package. Not simply fixable — deleting it and correcting it to `from .pdsfile import *` are both public-surface changes, one shrinking and one growing. Owner: PR-24 |
+| 32 | The commented-out `#     joined = _clean_join(a,b)…` line rode along in the byte-for-byte move. PR-22's dead-code line list was drawn against `pdsfile.py` and must be rebuilt against the post-Phase-5 module set. Owner: PR-22 |
+
+The reviewer also independently reproduced deferred entry 30
+(`repair_case('/', Pds3File)` → `UnboundLocalError`) and agreed entries 29 and 30
+are correctly scoped.
+
+## Regeneration
+
+This round's fixes touched only `plans/` and `critiques/`. Under §6.6 step 5 that
+does not stale the full-data record, so the runs recorded in
+`critiques/phase5-validation.md` §3 — generated after `37d4246`, both trees, both
+modes, both diffs empty — carry forward unchanged to round 3.

--- a/critiques/pr-16/round-3.md
+++ b/critiques/pr-16/round-3.md
@@ -1,0 +1,120 @@
+# PR-16 — adversarial review round 3
+
+**Date:** 2026-07-27
+**Reviewer:** a fresh, no-context opus-class subagent (§6.6 step 5), told not to
+read the earlier round records and told that the branch is deliberately unpushed
+because the loop precedes opening the PR.
+**Diff reviewed:** `origin/pr-15-latent-bug-fixes`(`1a5d85c`)`...HEAD`(`ded2adb`)
+**Verdict: goal met** — 0 Major, 6 Minor (all accepted and fixed, none rebutted),
+2 Deferred.
+
+## What the reviewer independently re-ran
+
+| Check | Reviewer's result |
+|---|---|
+| Byte-for-byte, per definition and as one blob | 12/12 identical; the contiguous run identical as a single 6,562-byte blob |
+| **`pdsfile.py` now has zero module-level functions**, and the parent had exactly the ten that moved | nothing left behind, nothing extra taken |
+| The sweep, re-derived | matches the record's table exactly; no module-level class referenced, so no deferred import needed; `PATH_EXISTS_CACHE_SIZE` genuinely unreferenced by the moved code |
+| Every reference, including the **consumer repos** | `rms-viewmaster/viewmaster/pdsiterator.py:104` uses `pdsfile.pdsfile.repair_case`; nothing in `rms-opus` or `rms-viewmaster` *rebinds* any moved name, so the re-export suffices |
+| The round-1 test fix, reproduced with `glob.glob` forced to return a hit | old site → resolves (test would fail on a MacOS install); new site → `ValueError` |
+| `dump_public_api.py`, `git archive` of the parent vs HEAD | byte-identical, 733,876 bytes each; `sorted(vars(pdsfile.pdsfile))` 45 names, set-identical; the only delta anywhere is each moved symbol's `__module__`, which the manifest does not record; `PdsFile.__module__` still `pdsfile.pdsfile` |
+| Ratchet, per code, plus an independent `--config 'lint.per-file-ignores = {}'` run | `pdsfile.py` still triggers all 23 codes; `_path_utils.py` exactly 3 errors, all E701/F841; no `noqa` added; `gen_ruff_ratchet.py` only prints, so the hand-written comment in the block is safe |
+| Full-data evidence: its own reduction of the four junit XMLs | byte-identical to the committed `.set` files; both diffs empty; counts match PR-15 §3b, i.e. the correct baseline |
+| Provenance: `parent-ns.log` `rootdir`, the worktree's detached head, and `coverage.CoverageData.measured_files()` on both `.coverage` files | baseline measured `<worktree>/src/pdsfile/pdsfile.py` with **no** `_path_utils.py`; head measured both |
+| No-holdings run; `tests/api/ tests/core/` | 59 passed / 800 skipped; 36 passed |
+| `critiques/phase5-validation.md` is **append-only** (0 removed lines) | no baseline record was edited |
+| LF, no CR, no trailing whitespace, `git diff --check`; packaging | clean |
+| Deferred entry 30 | reproduced |
+
+## Findings
+
+### Major
+
+**None.**
+
+### Minor 1 — the record undercounted this PR's deferred entries
+
+§10 said "Two new entries" and listed 29–30; the file had gained four (29–32),
+and §11's own round-2 row said "2 new entries", contradicting it. The preamble of
+the PR-16 section in `deferred-observations.md` still opened with "**Both**
+raised by…".
+
+**Accepted and fixed:** §10 is now a four-row table with a "raised in" and an
+"owner" column, and the observations file's preamble covers all four and says
+which round raised each.
+
+### Minor 2 — the round-1 row's counts did not sum
+
+"1 Major, 4 Minor, 2 Deferred — all **nine** accepted and fixed." 1 + 4 + 2 = 7,
+and the Deferred pair is by definition not "fixed".
+
+**Accepted and fixed:** "the Major and all four Minor accepted and fixed, none
+rebutted" — which is what happened.
+
+### Minor 3 — two wrong section cross-references
+
+The §2 gate table's ruff row pointed at §5; the ratchet evidence is §7. The API
+section's "See §5" for the F401/redundant-alias evidence should be §6.
+
+**Accepted and fixed.**
+
+### Minor 4 — the sub-plan's §8 header said "Four" and listed five
+
+**Accepted and fixed:** "Five".
+
+### Minor 5 — a committed record named distinctive components of the real holdings root
+
+`critiques/pr-16/round-2.md:26` listed `/home/rfrench`, `Shared-OPUS` and
+`/seti/opus` while describing the confidentiality grep — publishing two of the
+three distinctive segments of a path §3.4 says must appear in no committed file.
+The reviewer confirmed the full roots appear nowhere in tracked files, so this
+was a partial leak; it is nonetheless a line this PR added, in a file §3.4 names
+explicitly.
+
+**Accepted and fixed:** the row now says what was grepped by naming
+`$PDS3_HOLDINGS_DIR` / `$PDS4_HOLDINGS_DIR` and "their distinctive path
+components", with no literal. Re-grepped afterwards: the tokens appear in no file
+this PR touches.
+
+### Minor 6 — the new module's header described contents it does not have
+
+`src/pdsfile/_path_utils.py:3` said "Module-level path helpers shared by the
+PdsFile classes", but two of the ten symbols are not path helpers:
+`construct_category_list` builds the category-name cross-product and
+`formatted_file_size` formats a byte count. The module *name* is plan-mandated
+and is not a finding; the header sentence was the executor's, and was checkably
+false.
+
+**Accepted and fixed:** "Module-level path helpers and small support functions
+shared by the PdsFile classes."
+
+## Deferred (recorded, not fixed)
+
+- **Extend entry 29 to module-level *data*, not just modules.** `FILE_BYTE_UNITS`
+  is re-exported by `pdsfile.pdsfile` but read by `formatted_file_size` through
+  `_path_utils`'s globals, so an in-place mutation still works while a *rebind* of
+  `pdsfile.pdsfile.FILE_BYTE_UNITS` is now silently inert. Measured: no consumer
+  does either, so nothing is broken. **Folded into entry 29** as an explicit
+  extension, because PR-17 moves `PATH_EXISTS_CACHE_SIZE` into the same shape.
+- **Commit `37d4246` carries three logical changes under one `fix:` subject** —
+  the test stub site, the `_GLOB_CACHE_SIZE` re-export, and three comment
+  rewordings. The reviewer noted it does **not** violate the plan's binding rule
+  (the move commit `a5d2321` is clean of content edits, which is the rule §2
+  states), that the commit body discloses all three, and raised it only so the
+  pattern is visible for PR-17. Left as it stands: the branch's commit hashes are
+  cited throughout the validation record and the round records, and rewriting
+  history to split a disclosed round-1 fix would invalidate that evidence for a
+  cosmetic gain. Carried into PR-17 as a discipline note.
+
+## Rebuttals
+
+**None.** All six findings were accepted and fixed.
+
+## Regeneration
+
+Minor 6 touched `src/pdsfile/_path_utils.py` — a comment line — so under §6.6
+step 5 the full-data record was regenerated before round 4 rather than carried
+forward. Only the **head** side was re-run: the baseline tree is a detached
+worktree at `1a5d85c` that no round has touched, so its recorded set stands, and
+re-running it would measure the same unchanged tree. Both set diffs are still
+empty; the API dump is still byte-identical; `ruff` is clean.

--- a/critiques/pr-16/round-3.md
+++ b/critiques/pr-16/round-3.md
@@ -64,17 +64,24 @@ section's "See §5" for the F401/redundant-alias evidence should be §6.
 
 ### Minor 5 — a committed record named distinctive components of the real holdings root
 
-`critiques/pr-16/round-2.md:26` listed `/home/rfrench`, `Shared-OPUS` and
-`/seti/opus` while describing the confidentiality grep — publishing two of the
-three distinctive segments of a path §3.4 says must appear in no committed file.
-The reviewer confirmed the full roots appear nowhere in tracked files, so this
-was a partial leak; it is nonetheless a line this PR added, in a file §3.4 names
-explicitly.
+While describing the confidentiality grep, `critiques/pr-16/round-2.md:26` spelled
+out a two-component absolute prefix of the real holdings roots and one further
+distinctive path segment — the kind of fragment §3.4 says must appear in no
+committed file, in a file category §3.4 names explicitly. No complete root
+appeared anywhere, so this was a partial leak, which is why the reviewer
+classified it Minor.
 
-**Accepted and fixed:** the row now says what was grepped by naming
+**Accepted and fixed:** the row now describes what was grepped by naming
 `$PDS3_HOLDINGS_DIR` / `$PDS4_HOLDINGS_DIR` and "their distinctive path
-components", with no literal. Re-grepped afterwards: the tokens appear in no file
-this PR touches.
+components", quoting no literal.
+
+**Round 4 caught that this write-up originally reintroduced the same three
+literals in the course of describing them, so the fix is stated here without
+them.** The check is now mechanical rather than a claim: a scan of every tracked
+file for any run of two or more consecutive components of either real root
+reports **no file this PR adds or modifies**. It does report six pre-existing
+files that this PR does not touch; those are recorded as deferred entry 34 rather
+than cleaned up here, since fixing them is outside this PR's goal.
 
 ### Minor 6 — the new module's header described contents it does not have
 

--- a/critiques/pr-16/round-4.md
+++ b/critiques/pr-16/round-4.md
@@ -1,0 +1,109 @@
+# PR-16 — adversarial review round 4 (the scoped re-review)
+
+**Date:** 2026-07-27
+**Reviewer:** a fresh, no-context opus-class subagent. §6.6 makes the fourth
+round a *scoped* re-review — "confirm the prior round's findings are resolved;
+raise only **new Major** findings" — so this reviewer, unlike the first three,
+was given the three prior round records and asked to check each recorded finding
+against the tree rather than trust the record.
+**Diff reviewed:** `origin/pr-15-latent-bug-fixes`(`1a5d85c`)`...HEAD`(`8db74f7`)
+**Verdict: goal met** — **0 new Major**. 15 of 16 prior findings confirmed
+resolved and the one rebuttal confirmed sound; 1 prior Minor found only partly
+resolved; 2 non-blocking notes. All three are fixed below.
+
+## What the reviewer re-derived rather than reading off the records
+
+| Check | Reviewer's result |
+|---|---|
+| Byte-for-byte move, its own AST extraction | 12/12 identical; none of the twelve still defined in `pdsfile.py` |
+| **The rest of `pdsfile.py` is untouched** — parent `:249–6308` vs HEAD `:66–6125`, and the header on both | equal `md5` on both sides; the only changed region is the import block, no restyling rode along |
+| Nothing left behind, nothing extra taken | parent had exactly ten module-level functions; HEAD `pdsfile.py` has **zero**, one class, and `PATH_EXISTS_CACHE_SIZE`, still consumed |
+| The sweep, re-implemented from scratch | reproduces the record exactly, and confirms the decorator pass is load-bearing for `_GLOB_CACHE_SIZE` |
+| No cycle | `_path_utils.py`'s module-level imports are five stdlib `Import` nodes and nothing else |
+| API freeze — its own dump on a clean worktree at `1a5d85c` and on HEAD | byte-identical, 733,876 bytes each; the four prohibited files untouched |
+| **Namespace identity across all seven frozen top modules** | identical on both trees; the only additions to the `pdsfile` package namespace are `_path_utils` (underscore ⇒ skipped by the dumper and by `from pdsfile import *`) and the worktree's `_version` |
+| `sorted(vars(pdsfile.pdsfile))` | 45 names each side; all twelve the same objects; `PdsFile.__module__` unchanged |
+| Every reference, repo-wide and in both consumer repos | all resolve; **no file anywhere rebinds a moved name on `pdsfile.pdsfile`** |
+| Full-data evidence, its own reduction of all four junit XMLs | byte-equal to the committed `.set` files; both diffs empty id-by-id; counts match PR-15 §3b |
+| Freshness and provenance | head runs postdate `b86adba`; `rootdir` lines and the worktree's detached, clean `1a5d85c` with no `_path_utils.py` confirm the round-3 decision to re-run only the head side |
+| Ratchet code by code, plus an independent `--config 'lint.per-file-ignores = {}'` run | E701 16 → 14+2, F841 7 → 6+1, the other 21 codes unchanged and still triggered; `_path_utils.py` exactly 3 errors, all E701/F841 |
+| F401 with ignores cleared | 0 on HEAD `pdsfile.py`; the redundant-alias form is doing the work |
+| Round 1's Major fix, reproduced adversarially | only the committed stub site neutralizes the last-resort branch |
+| `tests/api/ tests/core/` **with all four holdings env vars unset** | 36 passed — the `holdings_free` promise holds |
+| Records are append-only | `phase5-validation.md` and `deferred-observations.md` both 0 removed lines, so PR-15's baseline section is untouched |
+| Hygiene, packaging, commit discipline | LF-only, no trailing whitespace, `git diff --check` clean; eight Conventional subjects; the move commit clean of content edits; the sub-plan precedes it |
+
+## New Major findings
+
+**None.** The reviewer's words: "I tried to break this PR on every axis a pure
+extraction can fail — a body altered in transit, a symbol left behind or dragged
+along, a missed module constant, an import cycle, a lost namespace entry, a
+manifest delta, a ratchet grow, a call site or patch site pointing at the vacated
+namespace, a vacuous baseline measurement, a stale or self-referential evidence
+set — and every one came back clean under my own recomputation."
+
+## Prior findings — 15 of 16 resolved, 1 rebuttal sound, 1 partly resolved
+
+Rounds 1 (Major 1, Minor 2–5), 2 (Minor 1–4) and 3 (Minor 1–4, 6) were each
+confirmed resolved **against the tree**, not against the record: the stub site by
+re-running the three-way simulation, the PR-number rule by
+`grep -rn "PR-[0-9]"` over `src/`, `scripts/` and `pyproject.toml` (no hits), the
+line count by re-measuring, the ruff command by running it verbatim and
+reproducing every number, the provenance by reading the four `rootdir` lines and
+the worktree's SHA, and `_GLOB_CACHE_SIZE` by the 45-name comparison.
+
+Round 2's Minor 5 rebuttal — "the PR does not exist yet" — was confirmed sound
+against the plan text: §6.6 terminates the loop and *then* opens the PR, so a
+reviewer cannot see the description at review time by construction.
+
+### Round 3's Minor 5 — only partly resolved, now fixed
+
+The offending row in `round-2.md` was correctly reworded, but the same commit
+wrote the three literals back into the tree in the sentence that *described* the
+finding, in `round-3.md`. The record's own "re-grepped afterwards: the tokens
+appear in no file this PR touches" was therefore false as written.
+
+**Accepted and fixed.** `round-3.md`'s Minor 5 is restated without any literal,
+and its verification is now a measurement rather than a claim: a scan of every
+tracked file for any run of two or more consecutive components of either real
+root reports **no file this PR adds or modifies**.
+
+The reviewer's classification of this as Minor rather than Major is recorded and
+accepted: no complete root appears anywhere in this PR's files (the longest run
+was 2 of 7 components), and the same scan finds **longer** runs already committed
+in six pre-existing files this PR does not touch — so this PR is not the
+disclosure vector. Those six are now deferred entry 34 rather than cleaned up
+here, since §6.6 makes "fix the pre-existing ones too" an invalid finding against
+a pure move PR.
+
+## Non-blocking notes — both actioned
+
+1. **A paragraph in §11 of the validation record contradicted its own preamble.**
+   It said "later rounds changed only `plans/` and `critiques/` … so the runs in
+   §3 carry forward", which stopped being true when round 3 touched
+   `_path_utils.py` and §3's head runs were *replaced* rather than carried
+   forward. The preamble said so correctly; commit `8db74f7` missed this
+   paragraph. **Fixed:** the paragraph now states which of the two regenerations
+   §3 records and why the baseline side was not re-run.
+2. **`scripts/gen_ruff_ratchet.py` emits an empty block against the current
+   tree**, because the committed `per-file-ignores` already suppress every
+   violation, so its documented "re-run and confirm the diff only removes codes"
+   workflow cannot be exercised without first clearing the table. Pre-existing,
+   not this PR's doing, and PR-23/PR-24 both depend on that workflow. **Recorded
+   as deferred entry 33.**
+3. The commented-out line inside `_clean_join` that rode along in the move is
+   already deferred entry 32; the reviewer agreed leaving it is correct in a
+   byte-for-byte move.
+
+## Regeneration
+
+This round's fixes touched only `critiques/`. Under §6.6 step 5 that does not
+stale the full-data record, so the runs recorded in
+`critiques/phase5-validation.md` §3 — regenerated after `b86adba`, both set diffs
+empty — stand as the evidence for the PR.
+
+## Termination
+
+§6.6's condition is met: a fresh reviewer returned **zero Major** findings with
+verdict `goal met`, inside the four-round cap. No Major was ever rebutted, so
+there is nothing to escalate under the anti-thrash rule.

--- a/critiques/pr-16/topology.md
+++ b/critiques/pr-16/topology.md
@@ -1,0 +1,32 @@
+# PR-16 execution topology
+
+Recorded per plan §6.7 ("Record the chosen topology in `critiques/`").
+
+The four-level nesting is collapsed from the top, which §6.7 prescribes as the
+fallback ("collapse levels from the **top**, never the bottom"):
+
+| Level | Who |
+|---|---|
+| Top-level coordinator | the interactive session |
+| Phase-5 coordinator | the interactive session (same context) |
+| **PR-executor for PR-16** | a dedicated subagent — carries implementation + the §6.6 loop end to end |
+| §6.6 adversarial reviewer | one fresh, no-context opus-class subagent **per round**, spawned by the PR-executor |
+
+What is preserved: exactly one PR-executor subagent for this PR, and under it a
+new reviewer per round that receives no implementation conversation, no executor
+reasoning and no prior round records — only the PR-16 section of the plan, the
+Phase-5 preamble, §2, §6.1/§6.2 and the §6.6 rules including the progressive
+`.cursor/rules` compliance schedule, the exact diff, and read access to the repo
+at HEAD and to the real holdings.
+
+PR-16 is the middle PR of a stacked series
+(`plans/2026-07-26-addendum-phase5-stacked-prs.md`): it branches off
+`pr-15-latent-bug-fixes` and its GitHub base is that branch, not `rewrite`. The
+diff handed to every reviewer is therefore
+`git diff origin/pr-15-latent-bug-fixes...HEAD` — a reviewer shown the cumulative
+diff against `rewrite` would flag PR-15's bug fixes as scope creep. PR-17
+branches off this PR's tip in turn, so this branch is never rebased or
+force-pushed after it is published.
+
+Rounds are recorded in `critiques/pr-16/round-<k>.md`; gate evidence is in
+`critiques/phase5-validation.md` (the phase file, per the Phase-5 preamble).

--- a/plans/2026-07-27-pr-16-subplan.md
+++ b/plans/2026-07-27-pr-16-subplan.md
@@ -122,7 +122,7 @@ moved body that cannot be kept byte-identical.
 ## 8. As executed — where the work diverged from §3–§7
 
 Appended after the fact rather than editing the sections above, so the plan that
-was written first stays readable as what it was. Four statements above are no
+was written first stays readable as what it was. Five statements above are no
 longer true of the delivered branch:
 
 1. **§1 and §3 say `_GLOB_CACHE_SIZE` is "private → not re-exported".** It *is*

--- a/plans/2026-07-27-pr-16-subplan.md
+++ b/plans/2026-07-27-pr-16-subplan.md
@@ -118,3 +118,44 @@ than copied, exactly as PR-15 re-measured `rewrite`'s.
 Any manifest diff at all; any pass/fail set movement in either direction; a ruff
 code needed by `_path_utils.py` that is not already in `pdsfile.py`'s entry; a
 moved body that cannot be kept byte-identical.
+
+## 8. As executed — where the work diverged from §3–§7
+
+Appended after the fact rather than editing the sections above, so the plan that
+was written first stays readable as what it was. Four statements above are no
+longer true of the delivered branch:
+
+1. **§1 and §3 say `_GLOB_CACHE_SIZE` is "private → not re-exported".** It *is*
+   re-exported. The Phase-5 preamble's rule — "`pdsfile.py` keeps re-exporting
+   every name it exports today" — carries no public/private qualifier, and the
+   adversarial review round 1 pointed out that reading it any other way is an
+   executor decision the plan has not delegated. Carrying it costs one line, is
+   freeze-invisible either way, and upgrades the claim to an exact invariant:
+   `sorted(vars(pdsfile.pdsfile))` is 45 names before and after, none lost, none
+   gained.
+2. **§3 step 2 says the extraction commit is "the only commit that touches
+   `src/pdsfile/`", and §Scope says "no test change".** Round 1 produced a second
+   source commit and a test change: the last-resort-glob stub in
+   `tests/core/test_pdsfile_path_resolution.py` was patching `pdsfile.pdsfile`,
+   which `abspath_for_logical_path` no longer resolves through, so it had stopped
+   reaching the code under test. Repointing it at the function's own
+   `__globals__` is exactly the "every reference is updated" half of a move PR,
+   so it belongs in this PR rather than a follow-up.
+3. **§6 check 9 as worded cannot pass.** "`import pdsfile._path_utils` as the
+   first pdsfile import → imports without touching `pdsfile.pdsfile`" is
+   unsatisfiable: importing any submodule runs `pdsfile/__init__.py`, which
+   star-imports `.pds3file`, which imports `pdsfile.pdsfile`. The check that
+   matters — and the one actually performed and recorded — is that
+   `_path_utils.py`'s module-level imports are stdlib-only and that it contains
+   no `from pdsfile.pdsfile import`, verified by parsing the module.
+4. **§2 understates the sweep.** The free-variable sweep answers "what must move
+   with the code"; it does not answer "does anything outside `src/` rebind one of
+   these names on the old module". That second direction is what finding 1 above
+   turned on, and it is now recorded as deferred entry 29 for PR-17 onward.
+5. **§5's `ruff check --isolated --select <code>` needs two more flags.**
+   `--isolated` also discards `line-length = 100`, which introduces an E501 the
+   project config does not report. The runs behind the recorded counts used
+   `--isolated --select <code> --line-length 100 --target-version py310`;
+   `critiques/phase5-validation.md` §7 gives the exact command.
+
+Everything else in §3–§7 was executed as written.

--- a/plans/2026-07-27-pr-16-subplan.md
+++ b/plans/2026-07-27-pr-16-subplan.md
@@ -1,0 +1,120 @@
+# PR-16 sub-plan — extract module-level path helpers → `_path_utils.py`
+
+**Date:** 2026-07-27
+**Parent plan:** `plans/2026-07-25-modernization-plan.md` §5 Phase 5, PR-16 (size L)
+**Branch:** `pr-16-path-utils`, based on `pr-15-latent-bug-fixes` @ `1a5d85c`
+**GitHub base:** `pr-15-latent-bug-fixes` (stacked — see
+`plans/2026-07-26-addendum-phase5-stacked-prs.md`)
+**Scope:** one new private module plus the import that re-exports it. No behavior
+change of any kind; no test change; no golden change.
+
+Written per §6.4 step 1 (PRs marked L get a short sub-plan first). It fixes the
+move order and the verification steps before the mechanical work starts.
+
+## 1. What moves
+
+Ten module-level symbols, located by name (the parent plan's ":47–247" window has
+drifted — PR-15 edited this file):
+
+`construct_category_list`, `logical_path_from_abspath`, `_clean_join`,
+`_clean_abspath`, `_clean_glob`, `_needs_glob`, `repair_case`,
+`formatted_file_size`, `abspath_for_logical_path`, `selected_path_from_path`.
+
+Plus the module constants those symbols reference, found by the sweep in §2:
+`FILE_BYTE_UNITS` (public → re-exported) and `_GLOB_CACHE_SIZE` (private →
+not re-exported; it is freeze-invisible and has no other reference in the tree).
+
+`PATH_EXISTS_CACHE_SIZE` stays in `pdsfile.py`: its consumer is the `lru_cache`
+on `os_path_exists`, which moves with `_local_fs.py` in PR-17.
+
+`abspath_for_logical_path` is moved in its **PR-15 form** — it reads
+`cls._HOLDINGS_ENV`, not the pre-PR-15 hard-coded `'PDS3_HOLDINGS_DIR'` literal.
+
+## 2. The sweep, done mechanically
+
+The parent plan requires a sweep "for any other pre-:47 module constant a moved
+symbol references". It is computed, not read: CPython's own `symtable` yields the
+module-global names each moved function's body references, **plus** an AST pass
+over each definition's decorator expressions and argument defaults, because those
+are evaluated in module scope and `symtable` does not attribute them to the
+function. That second pass is what finds `_GLOB_CACHE_SIZE` — it appears only in
+`@functools.lru_cache(maxsize=_GLOB_CACHE_SIZE)`, so a body-only sweep misses it
+and the extracted module would raise `NameError` at import.
+
+The sweep's full output goes in the validation record, including its "nothing
+else" lines: no module-level class is referenced (so there is no import cycle and
+no deferred import is needed), no module-level function stays behind, and no name
+is unclassified.
+
+## 3. Order of work
+
+1. **Sub-plan commit** (this file), before any code change.
+2. **Extraction commit** — the only commit that touches `src/pdsfile/`:
+   - create `src/pdsfile/_path_utils.py` with the ten definitions and the two
+     constants, bodies **byte-for-byte** as they stand on the parent branch, plus
+     the module header and the five stdlib imports the sweep names;
+   - delete the same lines from `pdsfile.py`;
+   - add the `from ._path_utils import (...)` block that both supplies the names
+     `pdsfile.py` still uses and re-exports the frozen ones;
+   - keep `glob` and `math` bound in `pdsfile.py` — both are frozen members of
+     `pdsfile.pdsfile`'s surface (`tests/api/api_manifest.json`) and neither is
+     referenced by the code that remains;
+   - adjust `[tool.ruff.lint.per-file-ignores]` per §5.
+   The tree is green at this commit; nothing else in the PR touches `src/`.
+3. **Record commits** — `critiques/pr-16/`, the `critiques/phase5-validation.md`
+   section, and any review-round fixes.
+
+## 4. Keeping `pdsfile.pdsfile.X` resolving
+
+Two import statements, deliberately separate:
+
+- the names `pdsfile.py` still calls (`_clean_join`, `repair_case`,
+  `abspath_for_logical_path`, …) — a plain `from ._path_utils import`;
+- the names nothing in `pdsfile.py` calls any more (`FILE_BYTE_UNITS`,
+  `selected_path_from_path`) — the same import in PEP-484 redundant-alias form
+  (`X as X`), which marks the re-export explicitly and is why `ruff` does not
+  read them as unused. `glob` and `math` keep their `import` statements in the
+  same form for the same reason. **No inline `noqa` and no new ratchet code** —
+  the ratchet comment in `pyproject.toml` forbids both.
+
+## 5. Ruff ratchet
+
+`per-file-ignores` may only shrink. Procedure, run per code rather than guessed:
+
+1. After the move, for every code in `pdsfile.py`'s current entry, run
+   `ruff check --isolated --select <code>` against `pdsfile.py` and against
+   `_path_utils.py`.
+2. `_path_utils.py` gets an entry listing **exactly** the codes the moved lines
+   still trigger. Every such code must already appear in `pdsfile.py`'s entry —
+   the entry is a split of an existing one, not a new suppression. **A code that
+   is not already there is a §6.4 hard stop**, not something to add.
+3. Any code `pdsfile.py` no longer triggers is **removed** from its entry.
+4. Net effect recorded as a before/after code count.
+
+The moved bodies are not restyled to avoid an inherited violation: that would be
+a content edit inside a move PR and it belongs to PR-23.
+
+## 6. Verification steps (all before the §6.6 loop)
+
+| # | Check | Passing means |
+|---|---|---|
+| 1 | Byte-for-byte: extract each moved definition's source segment from the parent commit's `pdsfile.py` and from `_path_utils.py`, diff | zero differing bytes for all ten symbols and both constants |
+| 2 | `python scripts/dump_public_api.py` on the parent worktree and on HEAD, `diff` | byte-identical dumps |
+| 3 | `pytest tests/api/test_api_freeze.py` | passes, allowlist untouched |
+| 4 | `ruff check src/pdsfile tests scripts` | clean; ratchet not widened (§5) |
+| 5 | Full-data `--mode ns` and `--mode s` with `--junitxml`, on the parent tip and on HEAD, per-test outcome sets diffed | **empty diff, both modes** — a pure extraction may not move the set in either direction |
+| 6 | `scripts/run-all-checks.sh` with no holdings env vars | same 59 passed / 800 skipped as the parent records |
+| 7 | `scripts/clean_install_check.sh` | passes — `_path_utils.py` must be picked up by the `pdsfile*` package glob |
+| 8 | Consumer-smoke Check A and Check B from `critiques/baselines/consumer-smoke-baseline.md` | **same outcome**: 4/4 for A; 5 ok / the same 3 failures for B; `pdsfile.pdsfile.repair_case` still resolves |
+| 9 | Import-cycle probe: `python -c "import pdsfile._path_utils"` as the *first* pdsfile import | imports without touching `pdsfile.pdsfile` |
+
+The §6.2 baseline for check 5 is **PR-15's recorded post-fix set**
+(`critiques/phase5-validation.md` §3b: ns 825 passed / 34 skipped, 859 ids;
+s 555 passed / 3 skipped, 558 ids), re-measured locally on the parent tip rather
+than copied, exactly as PR-15 re-measured `rewrite`'s.
+
+## 7. Hard stops for this PR
+
+Any manifest diff at all; any pass/fail set movement in either direction; a ruff
+code needed by `_path_utils.py` that is not already in `pdsfile.py`'s entry; a
+moved body that cannot be kept byte-identical.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,6 +157,10 @@ extend-ignore = ["PT011", "SIM105", "SIM108"]
 "scripts/check_runtime_imports.py" = ["RUF100"]
 "scripts/dump_public_api.py" = ["RUF100"]
 "src/pdsfile/__init__.py" = ["F403", "F841", "I001"]
+# Split off pdsfile.py's entry with the path helpers, not added to it: both codes
+# are pre-existing violations of the moved lines and both remain in pdsfile.py's
+# own entry for the lines that stayed. PR-23 is where they get fixed.
+"src/pdsfile/_path_utils.py" = ["E701", "F841"]
 "src/pdsfile/holdings_maintenance/pds3/crlf.py" = ["PT028"]
 "src/pdsfile/holdings_maintenance/pds3/pdsarchives.py" = ["A001", "C405", "F841", "I001", "RUF059", "SIM115", "UP031"]
 "src/pdsfile/holdings_maintenance/pds3/pdschecksums.py" = ["A001", "B006", "B007", "B012", "C405", "I001", "N806", "RUF059", "SIM115", "UP015", "UP024", "UP031"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,9 +157,8 @@ extend-ignore = ["PT011", "SIM105", "SIM108"]
 "scripts/check_runtime_imports.py" = ["RUF100"]
 "scripts/dump_public_api.py" = ["RUF100"]
 "src/pdsfile/__init__.py" = ["F403", "F841", "I001"]
-# Split off pdsfile.py's entry with the path helpers, not added to it: both codes
-# are pre-existing violations of the moved lines and both remain in pdsfile.py's
-# own entry for the lines that stayed. PR-23 is where they get fixed.
+# The same two codes appear in pdsfile.py's entry: these lines carry the ratchet's
+# existing E701 and F841 violations.
 "src/pdsfile/_path_utils.py" = ["E701", "F841"]
 "src/pdsfile/holdings_maintenance/pds3/crlf.py" = ["PT028"]
 "src/pdsfile/holdings_maintenance/pds3/pdsarchives.py" = ["A001", "C405", "F841", "I001", "RUF059", "SIM115", "UP031"]

--- a/src/pdsfile/_path_utils.py
+++ b/src/pdsfile/_path_utils.py
@@ -1,0 +1,219 @@
+##########################################################################################
+# pdsfile/_path_utils.py
+# Module-level path helpers shared by the PdsFile classes
+##########################################################################################
+
+import fnmatch
+import functools
+import glob
+import math
+import os
+
+# Configuration
+_GLOB_CACHE_SIZE = 200
+FILE_BYTE_UNITS = ['bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+
+##########################################################################################
+# Support functions
+##########################################################################################
+def construct_category_list(voltypes):
+    category_list = []
+    for checksums in ('', 'checksums-'):
+        for archives in ('', 'archives-'):
+            for voltype in voltypes:
+                category_list.append(checksums + archives + voltype)
+
+    category_list.remove('checksums-documents')
+    category_list.remove('archives-documents')
+    category_list.remove('checksums-archives-documents')
+
+    return category_list
+
+
+def logical_path_from_abspath(abspath, cls):
+    """Return the logical path derived from an absolute path.
+
+    Keyword arguments:
+        abspath -- the abosulte path of a file
+        cls     -- the class calling the other methods inside the function
+    """
+    parts = abspath.partition('/'+cls.PDS_HOLDINGS+'/')
+    if parts[1]:
+        return parts[2]
+
+    raise ValueError('Not compatible with a logical path: ', abspath)
+
+def _clean_join(a, b):
+#     joined = _clean_join(a,b).replace('\\', '/')
+    if a:
+        return a + '/' + b
+    else:
+        return b
+
+def _clean_abspath(path):
+    abspath = os.path.abspath(path)
+    if os.sep == '\\':
+        abspath = abspath.replace('\\', '/')
+    return abspath
+
+@functools.lru_cache(maxsize=_GLOB_CACHE_SIZE)
+def _clean_glob(cls, pattern, force_case_sensitive=False):
+    results = glob.glob(pattern)
+    if os.sep == '\\':
+        results = [x.replace('\\', '/') for x in results]
+
+    if force_case_sensitive and cls.FS_IS_CASE_INSENSITIVE:
+        filtered_results = []
+        for result in results:
+            result = repair_case(result, cls)
+            if fnmatch.fnmatchcase(result, pattern):
+                filtered_results.append(result)
+
+        return filtered_results
+
+    else:
+        return results
+
+def _needs_glob(pattern):
+    """Return True if the given expression contains wildcards
+
+    Keyword arguments:
+        pattern -- expression pattern
+    """
+    return '*' in pattern or '?' in pattern or '[' in pattern
+
+def repair_case(abspath, cls):
+    """Return a file's absolute path with capitalization exactly as it appears
+    in the file system. Raises IOError if the file is not found.
+
+    Keyword arguments:
+        abspath -- an absolute path of a file
+        cls     -- the class calling the other methods inside the function
+    """
+
+    trailing_slash = abspath.endswith('/')  # must preserve a trailing slash!
+    abspath = _clean_abspath(abspath)
+
+    # Fields are separated by slashes
+    parts = abspath.split('/')
+    if parts[-1] == '':
+        parts = parts[:-1]      # Remove trailing slash
+
+    # On Unix, parts[0] is always '' so no need to check case
+    # On Windows, this skips over the name of the drive
+
+    # For each subsequent field (between slashes)...
+    for k in range(1, len(parts)):
+
+        # Convert it to lower case for matching
+        part_lower = parts[k].lower()
+
+        # Construct the name of the parent directory and list its contents.
+        # This will raise an IOError if the file does not exist or is not a
+        # directory.
+        if k == 1:
+            basenames = os.listdir('/')
+        else:
+            basenames = cls.os_listdir('/'.join(parts[:k]))
+
+        # Find the first name that matches when ignoring case
+        found = False
+        for name in basenames:
+            if name.lower() == part_lower:
+
+                # Replace the field with the properly capitalized name
+                parts[k] = name
+                found = True
+                break
+
+    # Reconstruct the full path
+    if trailing_slash: parts.append('')
+    abspath = '/'.join(parts)
+
+    # Raise an IOError if last field was not found
+    if not found:
+        with open(abspath, 'rb') as f:
+            pass
+
+    return abspath
+
+def formatted_file_size(size):
+    order = int(math.log10(size) // 3) if size else 0
+    return f'{size / 1000.**order:.3g} {FILE_BYTE_UNITS[order]}'
+
+def abspath_for_logical_path(path, cls):
+    """Return the absolute path derived from the given logical path.
+
+    The logical path starts at the category, below the holdings/ directory. To
+    get the absolute path, we need to figure out where the holdings directory is
+    located. Note that there can be multiple drives hosting multiple holdings
+    directories.
+
+    Keyword arguments:
+        path -- the path of a file
+        cls  -- the class calling the other methods inside the function
+    """
+
+    # Check for a valid logical path
+    parts = path.split('/')
+    if parts[0] not in cls.CATEGORIES:
+        raise ValueError('Not a logical path: ' + path)
+
+    # Use the list of preloaded holdings directories if it is not empty
+    if cls.LOCAL_PRELOADED:
+        holdings_list = cls.LOCAL_PRELOADED
+
+    elif cls.LOCAL_HOLDINGS_DIRS:
+        holdings_list = cls.LOCAL_HOLDINGS_DIRS
+
+    elif cls._HOLDINGS_ENV in os.environ:
+        holdings_list = [os.environ[cls._HOLDINGS_ENV]]
+        cls.LOCAL_HOLDINGS_DIRS = holdings_list
+
+    # Without a preload or an environment variable, check the
+    # /Library/WebSever/Documents directory for a symlink. This only works for
+    # MacOS with the website installed, but that's OK.
+    else:
+        holdings_dirs = glob.glob('/Library/WebServer/Documents/holdings*')
+        holdings_dirs.sort()
+        holdings_list = [os.path.realpath(h) for h in holdings_dirs]
+        cls.LOCAL_HOLDINGS_DIRS = holdings_list
+
+    # With exactly one holdings/ directory, the answer is easy
+    if len(holdings_list) == 1:
+        return _clean_join(holdings_list[0], path)
+
+    # Otherwise search among the available holdings directories in order
+    for root in holdings_list:
+        abspath = _clean_join(root, path)
+        matches = cls.glob_glob(abspath)
+        if matches: return matches[0]
+
+    # File doesn't exist. Just pick one.
+    if holdings_list:
+        return _clean_join(holdings_list[0], path)
+
+    raise ValueError('No holdings directory for logical path ' + path)
+
+def selected_path_from_path(path, cls, abspaths=True):
+    """Return the logical path or absolute path derived from a logical or
+    an absolute path.
+
+    Keyword arguments:
+        path     -- the path of a file
+        cls      -- the class calling the other methods inside the function
+        abspaths -- the flag to determine if the return value is an absolute path (default
+                    True)
+    """
+
+    if cls.is_logical_path(path):
+        if abspaths:
+            return abspath_for_logical_path(path, cls)
+        else:
+            return path
+
+    else:
+        if abspaths:
+            return path
+        else:
+            return logical_path_from_abspath(path, cls)

--- a/src/pdsfile/_path_utils.py
+++ b/src/pdsfile/_path_utils.py
@@ -1,6 +1,7 @@
 ##########################################################################################
 # pdsfile/_path_utils.py
-# Module-level path helpers shared by the PdsFile classes
+# Module-level path helpers and small support functions shared by the PdsFile
+# classes
 ##########################################################################################
 
 import fnmatch

--- a/src/pdsfile/pdsfile.py
+++ b/src/pdsfile/pdsfile.py
@@ -7,8 +7,11 @@ import bisect
 import datetime
 import fnmatch
 import functools
-import glob
-import math
+# Nothing below references glob or math any more, but both are frozen members of
+# this module's public surface (tests/api/api_manifest.json), so it keeps them
+# bound. The redundant `as` alias is the explicit re-export form.
+import glob as glob
+import math as math
 import numbers
 import os
 import pickle
@@ -36,215 +39,26 @@ from .preload_and_cache import (cache_lifetime_for_class,
                                 pause_caching,
                                 resume_caching)
 
+# Path helpers, extracted to a private module. Importing them here is also what
+# keeps pdsfile.pdsfile.<name> resolving for callers and for the API freeze.
+from ._path_utils import (_clean_abspath,
+                          _clean_glob,
+                          _clean_join,
+                          _needs_glob,
+                          abspath_for_logical_path,
+                          construct_category_list,
+                          formatted_file_size,
+                          logical_path_from_abspath,
+                          repair_case)
+
+# Re-exported for the public surface only; nothing below references them. The
+# redundant `as` alias is the explicit re-export form, so they do not read as
+# unused imports.
+from ._path_utils import (FILE_BYTE_UNITS as FILE_BYTE_UNITS,
+                          selected_path_from_path as selected_path_from_path)
+
 # Configuration
-_GLOB_CACHE_SIZE = 200
 PATH_EXISTS_CACHE_SIZE = 200
-FILE_BYTE_UNITS = ['bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
-
-##########################################################################################
-# Support functions for pdsfile/__init__.py
-##########################################################################################
-def construct_category_list(voltypes):
-    category_list = []
-    for checksums in ('', 'checksums-'):
-        for archives in ('', 'archives-'):
-            for voltype in voltypes:
-                category_list.append(checksums + archives + voltype)
-
-    category_list.remove('checksums-documents')
-    category_list.remove('archives-documents')
-    category_list.remove('checksums-archives-documents')
-
-    return category_list
-
-
-def logical_path_from_abspath(abspath, cls):
-    """Return the logical path derived from an absolute path.
-
-    Keyword arguments:
-        abspath -- the abosulte path of a file
-        cls     -- the class calling the other methods inside the function
-    """
-    parts = abspath.partition('/'+cls.PDS_HOLDINGS+'/')
-    if parts[1]:
-        return parts[2]
-
-    raise ValueError('Not compatible with a logical path: ', abspath)
-
-def _clean_join(a, b):
-#     joined = _clean_join(a,b).replace('\\', '/')
-    if a:
-        return a + '/' + b
-    else:
-        return b
-
-def _clean_abspath(path):
-    abspath = os.path.abspath(path)
-    if os.sep == '\\':
-        abspath = abspath.replace('\\', '/')
-    return abspath
-
-@functools.lru_cache(maxsize=_GLOB_CACHE_SIZE)
-def _clean_glob(cls, pattern, force_case_sensitive=False):
-    results = glob.glob(pattern)
-    if os.sep == '\\':
-        results = [x.replace('\\', '/') for x in results]
-
-    if force_case_sensitive and cls.FS_IS_CASE_INSENSITIVE:
-        filtered_results = []
-        for result in results:
-            result = repair_case(result, cls)
-            if fnmatch.fnmatchcase(result, pattern):
-                filtered_results.append(result)
-
-        return filtered_results
-
-    else:
-        return results
-
-def _needs_glob(pattern):
-    """Return True if the given expression contains wildcards
-
-    Keyword arguments:
-        pattern -- expression pattern
-    """
-    return '*' in pattern or '?' in pattern or '[' in pattern
-
-def repair_case(abspath, cls):
-    """Return a file's absolute path with capitalization exactly as it appears
-    in the file system. Raises IOError if the file is not found.
-
-    Keyword arguments:
-        abspath -- an absolute path of a file
-        cls     -- the class calling the other methods inside the function
-    """
-
-    trailing_slash = abspath.endswith('/')  # must preserve a trailing slash!
-    abspath = _clean_abspath(abspath)
-
-    # Fields are separated by slashes
-    parts = abspath.split('/')
-    if parts[-1] == '':
-        parts = parts[:-1]      # Remove trailing slash
-
-    # On Unix, parts[0] is always '' so no need to check case
-    # On Windows, this skips over the name of the drive
-
-    # For each subsequent field (between slashes)...
-    for k in range(1, len(parts)):
-
-        # Convert it to lower case for matching
-        part_lower = parts[k].lower()
-
-        # Construct the name of the parent directory and list its contents.
-        # This will raise an IOError if the file does not exist or is not a
-        # directory.
-        if k == 1:
-            basenames = os.listdir('/')
-        else:
-            basenames = cls.os_listdir('/'.join(parts[:k]))
-
-        # Find the first name that matches when ignoring case
-        found = False
-        for name in basenames:
-            if name.lower() == part_lower:
-
-                # Replace the field with the properly capitalized name
-                parts[k] = name
-                found = True
-                break
-
-    # Reconstruct the full path
-    if trailing_slash: parts.append('')
-    abspath = '/'.join(parts)
-
-    # Raise an IOError if last field was not found
-    if not found:
-        with open(abspath, 'rb') as f:
-            pass
-
-    return abspath
-
-def formatted_file_size(size):
-    order = int(math.log10(size) // 3) if size else 0
-    return f'{size / 1000.**order:.3g} {FILE_BYTE_UNITS[order]}'
-
-def abspath_for_logical_path(path, cls):
-    """Return the absolute path derived from the given logical path.
-
-    The logical path starts at the category, below the holdings/ directory. To
-    get the absolute path, we need to figure out where the holdings directory is
-    located. Note that there can be multiple drives hosting multiple holdings
-    directories.
-
-    Keyword arguments:
-        path -- the path of a file
-        cls  -- the class calling the other methods inside the function
-    """
-
-    # Check for a valid logical path
-    parts = path.split('/')
-    if parts[0] not in cls.CATEGORIES:
-        raise ValueError('Not a logical path: ' + path)
-
-    # Use the list of preloaded holdings directories if it is not empty
-    if cls.LOCAL_PRELOADED:
-        holdings_list = cls.LOCAL_PRELOADED
-
-    elif cls.LOCAL_HOLDINGS_DIRS:
-        holdings_list = cls.LOCAL_HOLDINGS_DIRS
-
-    elif cls._HOLDINGS_ENV in os.environ:
-        holdings_list = [os.environ[cls._HOLDINGS_ENV]]
-        cls.LOCAL_HOLDINGS_DIRS = holdings_list
-
-    # Without a preload or an environment variable, check the
-    # /Library/WebSever/Documents directory for a symlink. This only works for
-    # MacOS with the website installed, but that's OK.
-    else:
-        holdings_dirs = glob.glob('/Library/WebServer/Documents/holdings*')
-        holdings_dirs.sort()
-        holdings_list = [os.path.realpath(h) for h in holdings_dirs]
-        cls.LOCAL_HOLDINGS_DIRS = holdings_list
-
-    # With exactly one holdings/ directory, the answer is easy
-    if len(holdings_list) == 1:
-        return _clean_join(holdings_list[0], path)
-
-    # Otherwise search among the available holdings directories in order
-    for root in holdings_list:
-        abspath = _clean_join(root, path)
-        matches = cls.glob_glob(abspath)
-        if matches: return matches[0]
-
-    # File doesn't exist. Just pick one.
-    if holdings_list:
-        return _clean_join(holdings_list[0], path)
-
-    raise ValueError('No holdings directory for logical path ' + path)
-
-def selected_path_from_path(path, cls, abspaths=True):
-    """Return the logical path or absolute path derived from a logical or
-    an absolute path.
-
-    Keyword arguments:
-        path     -- the path of a file
-        cls      -- the class calling the other methods inside the function
-        abspaths -- the flag to determine if the return value is an absolute path (default
-                    True)
-    """
-
-    if cls.is_logical_path(path):
-        if abspaths:
-            return abspath_for_logical_path(path, cls)
-        else:
-            return path
-
-    else:
-        if abspaths:
-            return path
-        else:
-            return logical_path_from_abspath(path, cls)
 
 ##########################################################################################
 # PdsFile class

--- a/src/pdsfile/pdsfile.py
+++ b/src/pdsfile/pdsfile.py
@@ -7,9 +7,9 @@ import bisect
 import datetime
 import fnmatch
 import functools
-# Nothing below references glob or math any more, but both are frozen members of
-# this module's public surface (tests/api/api_manifest.json), so it keeps them
-# bound. The redundant `as` alias is the explicit re-export form.
+# Nothing below references glob or math, but both are frozen members of this
+# module's public surface (tests/api/api_manifest.json), so it keeps them bound.
+# The redundant `as` alias is the explicit re-export form.
 import glob as glob
 import math as math
 import numbers
@@ -39,7 +39,7 @@ from .preload_and_cache import (cache_lifetime_for_class,
                                 pause_caching,
                                 resume_caching)
 
-# Path helpers, extracted to a private module. Importing them here is also what
+# The path helpers live in a private module. Importing them here is also what
 # keeps pdsfile.pdsfile.<name> resolving for callers and for the API freeze.
 from ._path_utils import (_clean_abspath,
                           _clean_glob,
@@ -51,10 +51,13 @@ from ._path_utils import (_clean_abspath,
                           logical_path_from_abspath,
                           repair_case)
 
-# Re-exported for the public surface only; nothing below references them. The
-# redundant `as` alias is the explicit re-export form, so they do not read as
-# unused imports.
+# Re-exported only; nothing below references these. FILE_BYTE_UNITS and
+# selected_path_from_path are frozen members of this module's public surface;
+# _GLOB_CACHE_SIZE is private, and is carried so that no name reachable as
+# pdsfile.pdsfile.<name> is lost. The redundant `as` alias is the explicit
+# re-export form, so they do not read as unused imports.
 from ._path_utils import (FILE_BYTE_UNITS as FILE_BYTE_UNITS,
+                          _GLOB_CACHE_SIZE as _GLOB_CACHE_SIZE,
                           selected_path_from_path as selected_path_from_path)
 
 # Configuration

--- a/tests/core/test_pdsfile_path_resolution.py
+++ b/tests/core/test_pdsfile_path_resolution.py
@@ -18,7 +18,6 @@ from types import SimpleNamespace
 import pytest
 
 from pdsfile import Pds3File, Pds4File
-from pdsfile import pdsfile as pdsfile_module
 from pdsfile.pdsfile import PdsFile, abspath_for_logical_path
 from tests.core.support import blank_pds3file
 
@@ -85,10 +84,12 @@ class TestHoldingsEnvironmentVariable:
         monkeypatch.delenv('PDS4_HOLDINGS_DIR', raising=False)
         monkeypatch.setattr(Pds4File, 'LOCAL_PRELOADED', [])
         monkeypatch.setattr(Pds4File, 'LOCAL_HOLDINGS_DIRS', None)
-        # The last-resort branch globs a MacOS website install. Replace the glob
-        # module the code resolves through rather than an attribute of the
-        # standard library's own module, so the stub reaches nothing else.
-        monkeypatch.setattr(pdsfile_module, 'glob',
+        # The last-resort branch globs a MacOS website install. Replace glob in
+        # the namespace the function itself resolves through -- its __globals__,
+        # whichever module that is -- rather than an attribute of the standard
+        # library's own module, so the stub reaches nothing else and stays
+        # attached if the function is moved again.
+        monkeypatch.setitem(abspath_for_logical_path.__globals__, 'glob',
                             SimpleNamespace(glob=lambda pattern: []))
 
         with pytest.raises(ValueError, match='No holdings directory'):


### PR DESCRIPTION
# Purpose

PR-16 of the modernization effort (`plans/2026-07-25-modernization-plan.md` §5, Phase 5, size **L**): extract the module-level path helpers out of the 6,308-line `pdsfile.py` into a private module. Part of the mechanical decomposition of `PdsFile` — issue #77, phase "a".

This is a **pure extraction**. No behavior changes, no golden changes, and the pass/fail set is identical in both modes. `pdsfile.py` re-exports every name it moved, so `pdsfile.pdsfile.X` resolves exactly as before.

**This PR is stacked** on PR-15 (#108) per the owner instruction recorded in `plans/2026-07-26-addendum-phase5-stacked-prs.md`. Its base is `pr-15-latent-bug-fixes`, not `rewrite`, so this diff is incremental; GitHub will retarget the base automatically when PR-15 merges. PR-17 branches off this tip in turn, so this branch will not be rebased or force-pushed.

Sub-plan (§6.4 step 1, required for an **L** PR, written before any code was touched): [`plans/2026-07-27-pr-16-subplan.md`](../blob/pr-16-path-utils/plans/2026-07-27-pr-16-subplan.md).

## Changes/Implementation Details

**What moved into `src/pdsfile/_path_utils.py`**, located by symbol rather than by the plan's line window (PR-15 had already shifted it): `construct_category_list`, `logical_path_from_abspath`, `_clean_join`, `_clean_abspath`, `_clean_glob`, `_needs_glob`, `repair_case`, `formatted_file_size`, `abspath_for_logical_path`, `selected_path_from_path`, plus two module constants.

`abspath_for_logical_path` moved in its **PR-15 form** — it reads `cls._HOLDINGS_ENV`, not the pre-PR-15 hard-coded `'PDS3_HOLDINGS_DIR'` literal.

**The sweep the plan asks for, done mechanically rather than by reading.** CPython's `symtable` gives the module-global names each moved body references; a second AST pass covers each definition's decorator expressions and argument defaults, which are evaluated in module scope and which `symtable` does not attribute to the function. That second pass is load-bearing: it is the only thing that finds `_GLOB_CACHE_SIZE`, which appears solely in `@functools.lru_cache(maxsize=_GLOB_CACHE_SIZE)`, and without which the extracted module raises `NameError` at import. Full result, including the "nothing else" lines:

| Category | Found |
|---|---|
| module-level **constants** referenced | `FILE_BYTE_UNITS` (named by the plan) and **`_GLOB_CACHE_SIZE`** (found by the sweep) |
| module-level **classes** referenced — the import-cycle risk | **none**, so no function-local deferred import was needed |
| module-level **functions** that would stay behind | **none** |
| unclassified names | **none** |
| stdlib imports the moved set needs | `fnmatch`, `functools`, `glob`, `math`, `os` |

`PATH_EXISTS_CACHE_SIZE` was left alone — its consumer is the `lru_cache` on `os_path_exists`, which moves with `_local_fs.py` in PR-17.

**Re-exports.** `pdsfile.py` imports every moved name back. Five of them are referenced nowhere in `pdsfile.py` any more but must stay bound: `glob`, `math`, `FILE_BYTE_UNITS` and `selected_path_from_path` are frozen members of `pdsfile.pdsfile`'s public surface (the manifest records imported modules as module-level names too, so dropping `import glob` would itself be a freeze break), and `_GLOB_CACHE_SIZE` is carried so that no name reachable as `pdsfile.pdsfile.<name>` is lost at all. All five use the PEP-484 redundant-alias form (`import glob as glob`), which ruff recognises as an explicit re-export — **no inline `noqa` and no new ratchet code**, both of which `pyproject.toml`'s ratchet header forbids. Measured: rewriting the five in plain form produces exactly five F401s; as committed, `pdsfile.py` reports **0** with no suppression of any kind.

**Ruff ratchet — no code gained.** `src/pdsfile/_path_utils.py` gets `["E701", "F841"]`, which is a **split** of `pdsfile.py`'s existing entry, not a new suppression: E701 was 16 instances in the parent's `pdsfile.py` and is now 14 + 2, F841 was 7 and is now 6 + 1. Every one of `pdsfile.py`'s 23 codes is still triggered by lines that stayed, so none could be dropped. A code needed by the new module that was *not* already in `pdsfile.py`'s entry would have been a §6.4 hard stop.

**Itemized keep-green edits** (§2 requires these be listed): the `from ._path_utils import` block in `pdsfile.py`; the redundant-alias form on `import glob` / `import math`; the `per-file-ignores` entry above. No packaging change was needed — `include = ["pdsfile*"]` picks the new module up, confirmed by the built wheel containing `pdsfile/_path_utils.py`.

**One test change**, and it is the "every reference is updated" half of a move PR rather than scope creep. `tests/core/test_pdsfile_path_resolution.py` replaced `glob` on `pdsfile.pdsfile` to neutralize `abspath_for_logical_path`'s last-resort MacOS-website branch. After the move the function resolves `glob` elsewhere, so the stub reached nothing and the test's outcome became a property of the machine rather than of the test — it still passed here only because this box has no `/Library/WebServer/Documents/holdings*`. It now patches the function's own `__globals__`, which follows the function wherever later PRs move it. Proved by forcing the real `glob.glob` to return a hit: the old stub site lets the resolution succeed, the new one still raises.

## Testing

Validation record: [`critiques/phase5-validation.md`](../blob/pr-16-path-utils/critiques/phase5-validation.md), PR-16 section. Holdings roots are named only by `PDS3_HOLDINGS_DIR` / `PDS4_HOLDINGS_DIR` per §3.4; the runs used the limited testing copy the goldens are tuned to.

**Full-data suite, both modes, per-test set diff — the §6.2 gate.** The baseline is **PR-15's recorded post-fix set**, not `rewrite`'s, and it was re-measured locally in a worktree at the parent tip rather than copied. Both passes ran the suite driver's exact command lines, serial, under coverage, with `-rA --junitxml`; every `testcase` element was reduced to one `outcome<TAB>classname::name` line, sorted, and diffed.

| Run | parent `1a5d85c` | `pr-16-path-utils` | set diff |
|---|---|---|---|
| `--mode ns` | 825 passed / 34 skipped (859 ids) | 825 passed / 34 skipped (859 ids) | **empty** |
| `--mode s` | 555 passed / 3 skipped (558 ids) | 555 passed / 3 skipped (558 ids) | **empty** |

No id was added, removed, or changed outcome, in either direction, in either mode. Because the interpreter is the main tree's venv, whose editable install puts the main `src` on `sys.path`, the record also proves *which* tree each run imported: `coverage.CoverageData.measured_files()` shows the baseline measured the worktree's `pdsfile.py` and **no** `_path_utils.py` (that file does not exist at `1a5d85c`), while the head runs measured both. Without that, a leak would have made the whole comparison vacuous.

**API freeze — empty, which is the only acceptable result for a pure extraction.** `pytest tests/api/` passes; `scripts/dump_public_api.py` run against the parent worktree and against HEAD produces **byte-identical** dumps (733,876 bytes each). Stronger still, and simpler to check: `sorted(vars(pdsfile.pdsfile))` is **45 names on each side, none lost and none gained** — the manifest skips underscore names, this does not. `pdsfile._path_utils` is underscore-prefixed and so is freeze-invisible where the submodule import binds it onto the package. `api_manifest.json`, `manifest_allowlist.json`, `scripts/dump_public_api.py` and `tests/api/test_api_freeze.py` are untouched and no allowlist entry was added.

**Byte-for-byte equivalence, measured.** Each moved definition's exact source segment (decorators included) was extracted from the parent commit's `pdsfile.py` and from `_path_utils.py` and compared byte by byte: all ten functions and both constants identical. The contiguous run from the first moved `def` to the last is also identical as a single 6,562-byte blob, which rules out a reordering or a dropped blank line. No moved body was restyled to dodge an inherited lint violation — that is PR-23's job. `pdsfile.pdsfile.X is pdsfile._path_utils.X` for all twelve names, so callers get the same objects, not copies.

**Other active gates:** `ruff check src/pdsfile tests scripts` clean; clean-install gate passes (throwaway venv, `pip install .`, full module surface imports); `scripts/run-all-checks.sh` with no holdings env vars — the hosted lint/no-holdings equivalent — **59 passed / 800 skipped**, identical to PR-15's.

**Consumer smoke — outcome unchanged.** `critiques/baselines/consumer-smoke-baseline.md` names this PR specifically: it records rms-viewmaster reaching `pdsfile.pdsfile.repair_case` at `pdsiterator.py:104` and says Phase 5's re-export is where a regression would show up. The gate is *same outcome as baseline*, not "passes".

| Check | Baseline | This branch |
|---|---|---|
| A — rms-opus import paths | 4/4 resolve, 0 failures | **4/4 resolve, 0 failures** |
| B — rms-viewmaster startup | 5 ok, 3 pre-existing failures | **5 ok, 3 failures — the same three** |

`pdsfile.pdsfile.repair_case` still resolves, and none of the three ground-rule-1 flat-name failures became a pass (fewer failures would mean pdsfile had grown a package-level name the ground rules forbid).

## Potential Impacts

**None on the public API**, proved twice over: a byte-identical manifest dump and a name-for-name identical `pdsfile.pdsfile` namespace. No behavior change; no CLI, log-format, file-format or exit-code change; no packaging change. `class PdsFile` and `PdsFile.__module__` stay in `pdsfile/pdsfile.py`, so pickles are unaffected. `pdsfile.py` goes from 6,308 to 6,125 lines; `_path_utils.py` is 219.

## Notes

**Adversarial review (§6.6) — four rounds, converged, records in [`critiques/pr-16/`](../tree/pr-16-path-utils/critiques/pr-16).**

| Round | Verdict | Findings |
|---|---|---|
| 1 | goal **not** met | **1 Major**, 4 Minor, 2 Deferred — the Major and all four Minor accepted and fixed, none rebutted |
| 2 | goal met | 0 Major, 5 Minor (4 fixed, 1 rebutted), 3 Deferred |
| 3 | goal met | 0 Major, 6 Minor (all fixed, none rebutted), 2 Deferred |
| 4 | goal met | **0 new Major**; scoped re-review confirmed 15 of 16 prior findings resolved and the one rebuttal sound; its 3 items fixed |

Round 1's Major is the one worth a reviewer's attention: the moved code was byte-perfect and every *call site* resolved, but a test **patched** the namespace the moved function used to resolve through, so it silently stopped exercising the code it was written for while still passing — and a per-test outcome-set diff is structurally blind to that. It is fixed here and generalized as deferred entry 29 for PR-17 onward.

One rebuttal, round 2's "the PR does not exist yet": §6.6 runs the loop to convergence and *then* opens the PR, so a reviewer cannot see the description at review time by construction. Round 4 confirmed the rebuttal sound. No Major was ever rebutted, so nothing escalates.

**Six new deferred observations** (`critiques/deferred-observations.md`), none fixable inside a pure move: **29** an extraction sweep must also ask which module namespaces the tests patch and which re-exported data they rebind (PR-17 onward); **30** `repair_case` raises `UnboundLocalError` on a single-component path, pre-existing and moved unchanged (PR-23); **31** `src/pdsfile/__init__.py`'s `from pdsfile import *` is a self-import that binds nothing and is not simply fixable — deleting it and correcting it are both public-surface changes (PR-24); **32** a commented-out line rode along in the move, so PR-22's dead-code line list must be rebuilt against the post-Phase-5 module set (PR-22); **33** `scripts/gen_ruff_ratchet.py` emits an empty block against the current tree, so the regeneration workflow PR-23/PR-24 rely on cannot be exercised as documented (PR-23); **34** six pre-existing tracked files carry multi-component fragments of the real holdings roots — no complete root, but one of them is a test module — which needs an owner decision on whether §3.4 should be enforced by a check rather than observed.

Nothing here is a hard stop and nothing needs a decision to merge this PR; **34** is the only item that wants an owner call, and it is about files this PR does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QyABhcZoxQaRjUjRnguHPK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved path handling for logical and absolute paths, normalization, case correction, wildcard detection, and file-size formatting.
  * Preserved existing path-related interfaces for compatibility.

* **Bug Fixes**
  * Improved path resolution across configured locations, environment settings, and platform-specific layouts.

* **Documentation**
  * Added detailed implementation, validation, and review records covering the path-handling updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->