### PR TITLE
docs: correct two Phase-5 plan statements executing the phase disproved

### DIFF
--- a/plans/2026-07-25-modernization-plan.md
+++ b/plans/2026-07-25-modernization-plan.md
@@ -476,18 +476,29 @@ every extraction PR:
   allowed only with an allowlist entry and owner sign-off, never silently.
 
 **PR-15 (M)** `fix: repair latent bugs in rarely/never-exercised core paths`
-Each fix gets a regression test first. **Note bug #1 is behavior-affecting**
-(it changes cache population for a live property), so unlike the genuinely
-dead bugs below it may legitimately shift the pass/fail set of the
+Each fix gets a regression test first. **Two of these are not dead code.**
+Bug #1 is behavior-affecting (it changes cache population for a live
+property), so it may legitimately shift the pass/fail set of the
 cached-behavior full-data tests — call that out in the PR with a recorded
-explanation (returned *values* are unchanged; only cache state is):
+explanation (returned *values* are unchanged; only cache state is). Bug #2 is
+a live crash on one deployment configuration (see its entry). The remaining
+five are genuinely unreached today, which is why they survived; their
+regression tests must be shown failing against the unfixed code, or they
+demonstrate nothing.
 1. `html_path` property: `self._recache` missing `()` (pdsfile.py:1785) — a
    no-op today, so `html_path` results are never cached; fixing to
    `self._recache()` (as the correct call at :3023 does) restores cache
    writeback for this live, commonly-used property.
 2. `get_permanent_values`: `resume_caching()` called without its `cls`
    argument (:712 — inside `get_permanent_values`, lines 665–714, **not**
-   `preload`, which starts at :840).
+   `preload`, which starts at :840). **This is reached in production, not
+   dead** (established while executing PR-15, 2026-07-27): `preload` calls
+   `get_permanent_values` at :941, on the `if cls.MEMCACHE_PORT:` branch taken
+   when nothing is missing from the cache — so on a **memcached deployment
+   with a warm cache**, `preload()` raises `TypeError` for the missing
+   positional argument. The bad call sits in a `finally:`, so it fires on the
+   success path too. Non-memcached deployments never reach it, which is how it
+   survived.
 3. `abspath_for_logical_path`: hard-coded `PDS3_HOLDINGS_DIR` env lookup in
    shared base breaks Pds4 resolution (:197–198). Fix semantics, exactly: add
    a **private** class attribute `_HOLDINGS_ENV` (`'PDS3_HOLDINGS_DIR'` on

--- a/plans/2026-07-25-modernization-plan.md
+++ b/plans/2026-07-25-modernization-plan.md
@@ -443,13 +443,25 @@ Every PR in this phase: API-freeze green, ruff/clean-install green, plus a
 per-test pass/fail set is diffed against the recorded baseline and recorded in
 `critiques/phase5-validation.md`** ("green" = identical set, §6.2). Technique:
 method groups move to **mixin classes** in new private modules
-(`class PdsFile(_ShelfMixin, _OpusMixin, …)`), module-level functions move to
+(`class PdsFile(_OpusMixin, _ShelfMixin, …)`), module-level functions move to
 private modules; `pdsfile/pdsfile.py` keeps re-exporting every name it
 exports today so `pdsfile.pdsfile.X` access is unchanged. Fixed mechanics for
 every extraction PR:
 - The `class PdsFile` statement itself **stays in `pdsfile/pdsfile.py`**
   (pickled instances and `PdsFile.__module__` keep their path; memcached
   pickles depend on it).
+- **Base order is alphabetical by mixin class name** (owner, 2026-07-27;
+  established by PR-17, which created the first two mixins and had to pick an
+  order to write the statement at all). The mixins are disjoint — the
+  collision test asserts they share no names and shadow nothing `PdsFile`
+  defines — so MRO order is behaviorally inert and the rule is chosen for
+  reviewability: every future mixin has exactly one legal position, derivable
+  without knowing which PR added what, and it is machine-checkable.
+  `tests/api/test_mixin_collisions.py` asserts it, so a base list in any other
+  order fails the gate. The illustration above is in that order. Trailing
+  `object` is **not** a mixin and is not required in Python 3; it predates
+  this effort and is left alone until PR-23's ruff cleanup, which already
+  carries `UP004` for that line.
 - Mixins define **no `__init__` and no new state** — methods/properties
   only, referencing existing instance/class attributes; class attributes
   (e.g. `SHELF_CACHE`) stay defined on `PdsFile`.


### PR DESCRIPTION
Two corrections to `plans/2026-07-25-modernization-plan.md`, both established by executing Phase 5 rather than by reading it. Docs only — no code, tests or CI, and it touches no file the PR-15 → PR-16 → PR-17 stack touches, so it merges independently and in any order.

## 1. Bug 2 is not dead code (`54d56bf`)

The PR-15 preamble grouped bugs 2–7 as "genuinely dead". That is wrong for bug 2.

`preload` calls `get_permanent_values` at `pdsfile.py:941`, on the `if cls.MEMCACHE_PORT:` branch — the one taken when nothing is missing from the cache. Inside that function the bad `resume_caching()` call (missing its `cls` argument) sits in a `finally:`, so it fires on the success path, not only on error. **On a memcached deployment with a warm cache, `preload()` raised `TypeError`.** Non-memcached deployments never reach it, which is how the defect survived.

Verified against `rewrite` before writing: `resume_caching()` at `:712` inside `get_permanent_values` (`:665`), called from `preload` at `:941`, in a `finally:` block.

The preamble now says which bugs are live rather than implying only bug 1 is, and repeats the requirement that the remaining five be shown failing against the unfixed code — the property that makes their regression tests mean anything.

## 2. The mixin base order is pinned (`98ac664`)

The preamble illustrated the technique as `class PdsFile(_ShelfMixin, _OpusMixin, …)` and fixed no ordering — it could not, since those two mixins never arrive in the same PR and the list ends in an ellipsis. But the class statement cannot be written without *some* order, and PR-17 creates the first two mixins, so it had to choose one. The owner settled it on 2026-07-27: **alphabetical by mixin class name**, asserted by `tests/api/test_mixin_collisions.py`.

The illustration sorted the other way (`_OpusMixin` precedes `_ShelfMixin`), so an executor of PR-18 through PR-22 reading only the plan would write a base list that fails the gate. The illustration is reordered and the rule is stated where those executors will read it, instead of living only in PR-17's addendum.

Rationale, recorded in the plan: the mixins are disjoint — the collision test asserts they share no names and shadow nothing `PdsFile` defines — so MRO order is behaviorally inert, and the rule is chosen for reviewability. Alphabetical gives every future mixin exactly one legal position, derivable without knowing which PR added what, and it is machine-checkable, so the convention survives executors who never read the addendum. The alternative, appending on arrival, would encode PR chronology into the class statement.

Also records what trailing `object` is doing in that list: **not a mixin, not required in Python 3** — `class PdsFile(_LocalFsMixin, _ShelfMixin)` gives the identical MRO — retained only because it predates this effort, and left for PR-23's ruff cleanup, which already carries `UP004` for that line.

## Why in the plan rather than only in the PR records

Both corrections currently live in `critiques/pr-15/` and `plans/2026-07-27-addendum-phase5-mixin-base-order.md`, on branches that have not merged. Later PR executors read the plan as fact — and the base-order one would actively mislead one into a red gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QyABhcZoxQaRjUjRnguHPK
