### PR TITLE
docs: record four owner decisions taken before PR-23

### DIFF
--- a/.cursor/rules/pdsfile_overrides.mdc
+++ b/.cursor/rules/pdsfile_overrides.mdc
@@ -20,15 +20,25 @@ conflicts with a rule below, follow the rule below. See
    `tests/api/api_manifest.json` and enforced by `tests/api/test_api_freeze.py`.
    Never edit the manifest, the allowlist, `scripts/dump_public_api.py`, or the
    freeze test to make a diff vanish.
-3. **Module-length limits are waived** for `pdsfile.py` and the per-dataset rule
-   files. This overrides `python.mdc`'s "modules < 1000 lines".
-4. **Rule modules and specific files carry permanent `ruff` exemptions.** Rule
-   modules are excluded from `ruff format` (they contain vertically aligned
-   `TranslatorByRegex` tables) **and** carry permanent `ruff check`
-   per-file-ignores. Core files and the subpackage `__init__`s carry a smaller
-   frozen set. The freeze-/table-/typing-locked sets (derived from an actual
-   `ruff check`, re-derived when the one-time reformat lands, not hardcoded on
-   faith) are, as of 2026-07-17:
+3. **Module-length limits are waived** for an explicit list of files, which
+   overrides `python.mdc`'s "modules < 1000 lines". The list is enumerated rather
+   than described as a class, so that adding a file to it is a visible decision:
+   - `src/pdsfile/pdsfile.py`
+   - `src/pdsfile/_properties.py` — the whole lazy-property block lives in one
+     mixin by owner decision (plan §8, settled decision 3)
+   - `src/pdsfile/pdscache.py` — over the line before this effort began; no phase
+     has splitting it as a deliverable
+   - the per-dataset rule files, `src/pdsfile/pds{3,4}file/rules/*.py`
+
+   Modules not on this list are held to the 1000-line limit. The maintenance
+   tools under `src/pdsfile/holdings_maintenance/` are **not** waived; Phase 6
+   consolidates them, so their sizes are expected to change.
+4. **Rule modules and specific files carry permanent `ruff check` exemptions.**
+   Rule modules carry permanent per-file-ignores; core files and the subpackage
+   `__init__`s carry a smaller frozen set. (`ruff format` does not run at all —
+   see (11) — so the rule modules' former format-exclusion is moot.) The
+   freeze-/table-/typing-locked sets (derived from an actual `ruff check`, not
+   hardcoded on faith) are, as of 2026-07-17:
    - `pds3file/rules/*.py`, `pds4file/rules/*.py` → `E501,W191,N801,N999,N802,N805,RUF012`
    - `pds3file/__init__.py`, `pds4file/__init__.py` → `F401,A002,RUF012`
    - core (`pdsfile.py`, `pdscache.py`, `pdsviewable.py`) → `B006,A002,RUF012`
@@ -76,3 +86,15 @@ conflicts with a rule below, follow the rule below. See
    `print()`-driven `shelf_consistency_check`) is frozen behavior.
 10. **The Python floor is 3.10** (matching the template's `requires-python`),
     overriding `python.mdc`'s "minimum 3.11".
+11. **`ruff format` is not enforced anywhere in this repository** (owner
+    decision, 2026-08-03;
+    `plans/2026-08-03-addendum-pr23-24-owner-decisions.md`). The one-time
+    reformat the plan made conditional on an owner churn checkpoint was measured
+    — 14 of 15 core files, ~2,310 changed lines — and dropped. The change is a
+    house-style conflict rather than a cleanup: this codebase aligns continuation
+    lines under the opening parenthesis, and `ruff format` rewrites them as one
+    element per line with a trailing comma, which would churn the multi-line
+    signatures inside the nine modules Phase 5 established as byte-for-byte
+    unchanged. Consequences: `ENABLE_RUFF_FORMAT` stays `false`, no CI job runs
+    `ruff format --check`, and `# fmt: off` guards are unnecessary and should not
+    be added. `[tool.ruff.format]`'s settings are inert but harmless.

--- a/critiques/deferred-observations.md
+++ b/critiques/deferred-observations.md
@@ -1519,7 +1519,17 @@ against all five mixins (`critiques/phase5-validation.md`, PR-19 §11).
 
 ### Added by the PR-22 adversarial review (round 2)
 
-65. **The "modules < 1000 lines" waiver names `pdsfile.py` and the rule modules,
+65. **RESOLVED — owner decision, 2026-08-03**
+    (`plans/2026-08-03-addendum-pr23-24-owner-decisions.md`): the waiver becomes
+    an **explicit list of modules** — `pdsfile.py`, `_properties.py`,
+    `pdscache.py`, and the rule modules — enumerated rather than described as a
+    class, so that adding a file to it is a visible decision. `pdscache.py` stays
+    at its current size, waived. Splitting `_properties.py` was rejected because
+    it would reopen §8 settled decision 3. Recorded in
+    `.cursor/rules/pdsfile_overrides.mdc` (3) and in §6.6's schedule. The
+    original entry follows, unaltered.
+
+    **The "modules < 1000 lines" waiver names `pdsfile.py` and the rule modules,
     and Phase 5 has now produced two other files over the line.** §6.6's
     progressive-compliance schedule reads: `python.mdc` "modules < 1000 lines" —
     **permanently waived** for `pdsfile.py` and rule modules. At the end of
@@ -1540,3 +1550,26 @@ against all five mixins (`critiques/phase5-validation.md`, PR-19 §11).
     module Phase 5 produced, or the owner wants `_properties.py` split further,
     which would be phase "b" work rather than PR-23's.
     **Owner: owner decision, before PR-23's churn checkpoint.**
+
+### Added by the PR-23/PR-24 owner decisions (2026-08-03)
+
+66. **Three maintenance-tool modules are over 1000 lines and are deliberately
+    not waived.** Measuring the explicit waiver list for entry 65 turned up files
+    the decision was not asked about:
+    `src/pdsfile/holdings_maintenance/pds3/pdslinkshelf.py` (**1,779**),
+    `src/pdsfile/holdings_maintenance/pds4/pds4linkshelf.py` (**1,274**) and
+    `src/pdsfile/holdings_maintenance/pds3/pdsdependency.py` (**1,166**).
+    (`src/pdsfile/pds3file/rules/VG_28xx.py` at 1,017 is already covered by the
+    rule-module entry.)
+
+    They were left off the waiver on purpose rather than by oversight. **Phase 6
+    (PR-25 onward) consolidates the duplicated pds3/pds4 tool logic into
+    `_common.py`**, so these sizes are expected to change; waiving them now would
+    pre-empt that work with a statement about to stop being true. Nothing is
+    broken in the meantime — no gate enforces module length (`ruff`'s select set
+    has no such check), so this is a documentation question, not a failing check.
+
+    Whether they end up waived, split, or shrunk by the consolidation is a
+    Phase-6 question, answerable once PR-25 has established how much of each file
+    is duplication.
+    **Owner: Phase 6 (PR-25 onward).**

--- a/plans/2026-07-25-modernization-plan.md
+++ b/plans/2026-07-25-modernization-plan.md
@@ -189,7 +189,7 @@ for re-interpretation by the executor:
 | Full-data suite (self-hosted CI on every PR; also run locally) | **Active** (Phase 0) | No behavior change against real holdings; per-test pass/fail set identical to the recorded baseline (§6.2); additionally run locally after every Phase 5/6 PR and at each phase boundary |
 | `ruff check` (ratcheted) | **Active** (PR-03) | Style; per-file-ignores may only shrink |
 | Clean-install import check | **Active** (PR-08) | `pip install .` with no extras; `import pdsfile` + every manifest module imports (runtime-dep leak guard) |
-| `ruff format --check` | PR-23 (core) / PR-24 (rest) — **conditional on the owner churn checkpoints in those PRs**; scope may be reduced or the gate dropped entirely | Formatting; not gated before the one-time reformat lands |
+| `ruff format --check` | **Never enabled** — the churn checkpoint ran on 2026-08-03 and the owner dropped the reformat entirely (`plans/2026-08-03-addendum-pr23-24-owner-decisions.md`) | — |
 | Hosted lint/no-holdings CI job | **Active** (PR-14) | ruff + pyroma + API-freeze + clean-install + the holdings-free test subset on stock GitHub runners (it runs `run-all-checks.sh`, so it is whatever that enables) |
 | sphinx -W -n build | PR-31 | Docs build clean |
 | Adversarial pre-PR review loop | **Active** (every PR) | A fresh, no-context reviewer cannot prove the PR misses its stated goal — zero Major and no new un-rebutted Minor findings (§6.6) |
@@ -642,25 +642,20 @@ defaults like `SUBCLASSES = {}`, `SHELF_CACHE = {}`, `VOLTYPES = [...]` — the
 only ruff fix is a `ClassVar` annotation, forbidden by ground rule 5). The
 ratchet shrinks to **only** this enumerated freeze-locked set for these files,
 not to zero.
-**Formatting — mandatory owner checkpoint (hard stop) before committing any
-reformat:**
-1. First run `ruff format --diff` over the target file set and measure the
-   churn (files touched, lines changed, and a skim of *what kind* of change
-   dominates). Before measuring, protect deliberately aligned code: any block
-   that is vertically aligned to look good (aligned assignment columns,
-   hand-shaped tables or literals) gets `# fmt: off` / `# fmt: on` guards so
-   the formatter leaves it alone.
-2. **Stop and present the churn numbers and diff samples to the owner.** The
-   owner decides: proceed as scoped, reduce the scope (more exclusions / more
-   `fmt: off` guards), or **drop the reformat entirely**. Do not commit any
-   reformatting before this decision.
-3. Only on an explicit go: run the one-time `ruff format` over the approved
-   set and enable the `ruff format --check` gate (CI lint + run-all-checks)
-   scoped to it. If the owner drops or reduces formatting, the gate matches
-   the reduced scope (or is never enabled) and the decision is recorded in
-   `pdsfile_overrides.mdc`.
+**Formatting — settled, no checkpoint remains.** The churn checkpoint this
+section used to require **ran on 2026-08-03 against merged `rewrite`** (14 of 15
+files, ~2,310 changed lines) and the owner **dropped the reformat entirely**
+(`plans/2026-08-03-addendum-pr23-24-owner-decisions.md`). So: do **not** run
+`ruff format`, do **not** enable the `ruff format --check` gate, and do **not**
+add `# fmt: off` / `# fmt: on` guards — they exist only to protect aligned blocks
+from a formatter that will not run. `ENABLE_RUFF_FORMAT` stays `false`. PR-23 is
+a **`ruff check` PR only**.
 No behavior change; full-data run to prove it. Record the freeze-locked set in
 `pdsfile_overrides.mdc`.
+
+**Branch and base:** PR-23 and PR-24 are **not stacked** (owner, 2026-08-03).
+Each branches from `rewrite`, opens against `rewrite`, and merges before the next
+begins; PR-24's §6.2 baseline is `rewrite` after PR-23 lands.
 
 **PR-24 (L, mechanical)** `style: ruff-clean and format rules and remaining files`
 Rules files + pds3file/pds4file `__init__` (including deduplicating the
@@ -701,16 +696,15 @@ the method (deleting the method would change behavior and the manifest kind).
   `__all__` for `support.py`); any residue is enumerated like the other
   permanent ignores. **Record the full per-file-class freeze-locked set in
   `pdsfile_overrides.mdc` deviation (4).**
-- Formatting: **same mandatory owner checkpoint as PR-23** — `ruff format
-  --diff` first, churn numbers and samples to the owner, no reformat
-  committed before an explicit go/reduce/drop decision. Scope: everything
-  remaining **except the rule modules and `re_validate.py`** (both in
-  `[tool.ruff.format] exclude`; the rule modules for the hand-aligned tables,
-  `re_validate.py` because ground rule 7 / deviation (6) freeze it).
-  Additionally, **vertically aligned code is never reformatted**: the aligned
-  `pytest.mark.parametrize` tables in the test tree and any other block lined
-  up for readability get `# fmt: off` / `# fmt: on` guards before the churn
-  measurement.
+- Formatting: **none — dropped by the owner on 2026-08-03 along with PR-23's**
+  (`plans/2026-08-03-addendum-pr23-24-owner-decisions.md`). No `ruff format`, no
+  `ruff format --check` gate, no `# fmt: off` guards. PR-24 is a **`ruff check`
+  PR only**. The aligned `pytest.mark.parametrize` tables in the test tree and
+  the rule modules' `TranslatorByRegex` tables need no protection, because
+  nothing will reformat them.
+- **Branch and base:** PR-24 branches from `rewrite` **after PR-23 has merged**
+  and opens against `rewrite`; the two are not stacked (owner, 2026-08-03). Its
+  §6.2 baseline is `rewrite` at that point.
 - **`re_validate.py` also gets a permanent `ruff check` per-file-ignore set**
   (its full derived violation set — UP031, E402, RUF059, E701, I001, B007,
   RUF005, C405, RUF051, E721, UP034 as of 2026-07-17), for the same freeze
@@ -973,8 +967,10 @@ line-by-line human review at its boundary.
   categories (§6.1).
 - Any full-data run whose pass/fail set differs from the baseline without a
   cause the executor can prove is the intended, documented change of that PR.
-- **The PR-23 and PR-24 formatting churn checkpoints** (mandatory owner
-  decision — go / reduce scope / drop — before committing any reformat).
+- ~~The PR-23 and PR-24 formatting churn checkpoints.~~ **Discharged
+  2026-08-03**: the checkpoint ran and the owner dropped the reformat entirely
+  (`plans/2026-08-03-addendum-pr23-24-owner-decisions.md`). Running `ruff format`
+  is now itself the hard stop.
 - Any situation where following the plan would require changing behavior,
   file formats, CLI flags, log formats, or exit codes not explicitly listed
   as changing.
@@ -1094,9 +1090,9 @@ Then open the PR.
   | `dependency_management.mdc` (pyproject single source) | **Active** (PR-03) |
   | `environment.mdc` (`run-all-checks.sh` = CI source of truth) | **Active** (PR-04), tightened at PR-14 |
   | `python.mdc` style/naming/line-length (`ruff check`) | ratcheted since PR-03; from PR-23 (core) / PR-24 (rest) reduced to the enumerated freeze-/table-locked permanent ignore sets |
-  | `python.mdc` `ruff format` | PR-23/PR-24 — only to the extent the owner approves at those PRs' churn checkpoints |
+  | `python.mdc` `ruff format` | **never enforced** (owner, 2026-08-03 — the churn checkpoint ran and the reformat was dropped) |
   | `python.mdc` type annotations / mypy | **permanently waived** (ground rule 5); `.pyi` stubs at PR-35 only |
-  | `python.mdc` "modules < 1000 lines" | **permanently waived** for `pdsfile.py` and rule modules |
+  | `python.mdc` "modules < 1000 lines" | **permanently waived** for the explicit list in `pdsfile_overrides.mdc` (3): `pdsfile.py`, `_properties.py`, `pdscache.py`, and the rule modules. Everything else is held to the limit |
   | `python_testing.mdc` (pytest/markers/coverage) | Phase 3–4 (PR-08–PR-14); the hermetic aspects are out of scope (see the scope note) |
   | `doc_python.mdc` docstrings; `doc_readme`/`doc_dev_guide`/`doc_user_guide` | Phase 7 (PR-29–PR-34) |
   | `logging.mdc` (PdsLogger) | already followed; enforced only where a PR edits logging; waived for the tools' frozen `print()` output |

--- a/plans/2026-08-03-addendum-pr23-24-owner-decisions.md
+++ b/plans/2026-08-03-addendum-pr23-24-owner-decisions.md
@@ -1,0 +1,101 @@
+# Addendum: four owner decisions taken before PR-23
+
+**Date:** 2026-08-03
+**Status:** **ACKNOWLEDGED** — these are owner instructions, recorded here for
+provenance. They are not requests for a decision.
+**Amends:** `plans/2026-07-25-modernization-plan.md` §2 (gate table), §5 (PR-23
+and PR-24), §6.5 and §6.6 (compliance schedule), and
+`.cursor/rules/pdsfile_overrides.mdc` deviations (3) and (4).
+
+Phase 5's decomposition (PR-15 … PR-22) merged to `rewrite` on 2026-08-03 at
+`a179163`. PR-23 and PR-24 are the two ruff PRs that close Phase 5. Four
+questions were put to the owner before PR-23 began, because each of them changes
+what PR-23 is allowed to do; all four were answered the same day.
+
+## 1. The module-length waiver becomes an explicit list
+
+Deferred observation 65 asked how to reconcile the waiver with what Phase 5
+produced. `python.mdc` requires modules under 1000 lines;
+`pdsfile_overrides.mdc` deviation (3) waived it for `pdsfile.py` and the rule
+modules — a list written before the decomposition existed.
+
+**Decision: enumerate the waived modules explicitly** rather than describing them
+as a class. A named list has to be amended when a module joins it, and that is
+the point: an addition is a visible decision rather than something that quietly
+qualifies.
+
+Splitting `_properties.py` was the alternative and was rejected. It would reopen
+§8 settled decision 3, which deliberately puts the whole lazy-property block in a
+single mixin so that core lands near ~1,750 lines.
+
+## 2. `pdscache.py` stays at its current size, waived
+
+**Decision: leave `pdscache.py` as it is and waive it.** It was over the line
+before this effort began (1,044 lines, unchanged by Phase 5), and no phase in
+this plan has splitting it as a deliverable.
+
+## 3. The `ruff format` requirement is dropped
+
+The plan made the one-time reformat conditional on an owner churn checkpoint at
+PR-23 and PR-24 (§5, both PRs, step 2: "Stop and present the churn numbers and
+diff samples to the owner. The owner decides: proceed as scoped, reduce the
+scope, or **drop the reformat entirely**").
+
+**The churn was measured on merged `rewrite` and presented: 14 of 15 files in
+PR-23's target set would be reformatted, ~2,310 changed lines** — an upper bound,
+taken before any `# fmt: off` guards.
+
+What the diff showed is not cleanup but a house-style conflict. This codebase
+aligns continuation lines under the opening parenthesis; `ruff format` breaks
+each element onto its own line with a trailing comma. The change would therefore
+rewrite the multi-line imports, the nine-mixin `class PdsFile(...)` statement,
+and every multi-line signature — including those inside the nine modules whose
+entire warrant is that their bodies moved byte-for-byte, a property four
+adversarial review rounds per PR were spent establishing.
+
+**Decision: drop the reformat entirely.** Consequences, per the plan's own step 3
+("If the owner drops or reduces formatting, the gate matches the reduced scope
+(or is never enabled) and the decision is recorded in `pdsfile_overrides.mdc`"):
+
+- The one-time `ruff format` is **not run**, in PR-23, in PR-24, or later.
+- The `ruff format --check` gate is **never enabled**. `ENABLE_RUFF_FORMAT` stays
+  `false` in `scripts/run-all-checks.sh` and no CI job adds it.
+- PR-23 and PR-24 keep their **`ruff check`** halves in full: deriving each
+  file's violations, fixing the fixable ones, and shrinking the ratchet to the
+  enumerated freeze-locked set. That work is unaffected.
+- The `# fmt: off` / `# fmt: on` guards the checkpoint would have required are
+  **not needed** and should not be added — they exist only to protect aligned
+  blocks from a formatter that will not run.
+- `[tool.ruff.format]`'s `quote-style = "single"` setting is inert but harmless;
+  it stays, and its comment already says formatting is not enforced.
+
+## 4. PR-23 and PR-24 are executed one at a time
+
+Phase 5's decomposition was executed as an eight-deep stack of PRs, each based on
+its predecessor (`plans/2026-07-26-addendum-phase5-stacked-prs.md`,
+`plans/2026-07-27-addendum-phase5-stack-extension.md`).
+
+**Decision: PR-23 and PR-24 are not stacked.** Each branches from `rewrite`,
+opens against `rewrite`, and merges before the next begins — the topology §6.7
+describes by default. Stacking existed only to avoid blocking on review, and its
+one real cost is now understood: a squash-merge of any stack element rewrites the
+history its children are built on and forces a rebase of everything above it.
+
+Consequences: PR-24's §6.2 baseline is `rewrite` after PR-23 merges, not PR-23's
+branch tip; each PR's reviewer diff is against `rewrite`; no forward-merging
+between them.
+
+## An open item this addendum does not decide
+
+Measuring the waiver list turned up **three maintenance-tool modules over 1000
+lines that decision 1 was not asked about**:
+`holdings_maintenance/pds3/pdslinkshelf.py` (1,779),
+`holdings_maintenance/pds4/pds4linkshelf.py` (1,274) and
+`holdings_maintenance/pds3/pdsdependency.py` (1,166). One rule module,
+`pds3file/rules/VG_28xx.py` (1,017), is already covered by the rule-module entry.
+
+They are deliberately **not** added to the waiver here. Phase 6 (PR-25 onward)
+consolidates the duplicated pds3/pds4 tool logic into `_common.py`, so their
+sizes are expected to change; waiving them now would pre-empt that work with a
+statement that is about to stop being true. Whether they end up waived or split
+is a Phase-6 question. Recorded as deferred observation 66.

--- a/scripts/run-all-checks.sh
+++ b/scripts/run-all-checks.sh
@@ -58,7 +58,8 @@
 #   ENABLE_* are true (RUN_* from CLI or defaults below; ENABLE_* from env; see
 #   pdsfile_overrides.mdc for which checks are permanently off):
 #     ENABLE_RUFF_CHECK   (default: true)
-#     ENABLE_RUFF_FORMAT  (default: false — not enforced yet)
+#     ENABLE_RUFF_FORMAT  (default: false — never; owner dropped the one-time
+#                          reformat 2026-08-03, see pdsfile_overrides.mdc (11))
 #     ENABLE_MYPY         (default: false — never; no inline typing)
 #     ENABLE_PYTEST       (default: true)
 #     ENABLE_PYROMA       (default: true)


### PR DESCRIPTION
Records the four decisions the owner took on 2026-08-03, before PR-23 begins. Docs, rules and one shell comment only — no code, no tests, no gate behavior change. `plans/2026-08-03-addendum-pr23-24-owner-decisions.md` is the provenance record; the plan, `pdsfile_overrides.mdc`, `run-all-checks.sh`'s flag comment and `critiques/deferred-observations.md` are updated to agree with it.

## 1. The module-length waiver becomes an explicit list

`pdsfile_overrides.mdc` (3) waived `python.mdc`'s "modules < 1000 lines" for "`pdsfile.py` and the per-dataset rule files" — a list written before the decomposition existed. It is now enumerated: **`pdsfile.py`, `_properties.py`, `pdscache.py`, and the rule modules.** A named list has to be amended when a module joins it, and that is the point — an addition becomes a visible decision rather than something that quietly qualifies.

Splitting `_properties.py` (1,686 lines) was the alternative and was rejected: it would reopen §8 settled decision 3, which deliberately puts the whole lazy-property block in a single mixin so core lands near ~1,750.

Resolves deferred observation 65, whose measurement is kept intact above the resolution.

## 2. `pdscache.py` stays at its current size, waived

1,044 lines, over the limit before this effort began and untouched by Phase 5. No phase in this plan has splitting it as a deliverable.

## 3. The `ruff format` requirement is dropped

The plan made the one-time reformat conditional on an owner churn checkpoint at both PR-23 and PR-24. **That checkpoint has now run**, measured against merged `rewrite`: **14 of 15 files in PR-23's target set, ~2,310 changed lines**, before any `# fmt: off` guards.

What the diff shows is a house-style conflict, not a cleanup. This codebase aligns continuation lines under the opening parenthesis; `ruff format` rewrites them as one element per line with a trailing comma. It would therefore churn the multi-line imports, the nine-mixin `class PdsFile(...)` statement, and every multi-line signature — including those inside the nine modules whose entire warrant is that their bodies moved byte-for-byte, a property four adversarial review rounds per PR were spent establishing.

**Dropped entirely.** Following the plan's own step 3, which specified what dropping means:

- `ruff format` is not run, in PR-23, PR-24, or later.
- The `ruff format --check` gate is never enabled; `ENABLE_RUFF_FORMAT` stays `false` and no CI job adds it.
- `# fmt: off` / `# fmt: on` guards are **not** needed and should not be added — they exist only to protect aligned blocks from a formatter that will not run.
- PR-23 and PR-24 keep their **`ruff check`** halves in full: derive each file's violations, fix the fixable ones, shrink the ratchet to the enumerated freeze-locked set. Unaffected.

The `§6.4` hard-stop entry for the checkpoint is marked discharged rather than deleted, and now says the opposite thing: running `ruff format` is itself the hard stop.

## 4. PR-23 and PR-24 are executed one at a time

Not stacked. Each branches from `rewrite`, opens against `rewrite`, and merges before the next begins — §6.7's default topology. Stacking existed only to avoid blocking on review, and its real cost is now understood: a squash-merge of any stack element rewrites the history its children are built on and forces a rebase of everything above it, which is exactly what happened to this stack at #108.

## One thing this does not decide

Measuring the waiver list turned up three maintenance-tool modules over 1000 lines that the question never covered: `pdslinkshelf.py` (1,779), `pds4linkshelf.py` (1,274), `pdsdependency.py` (1,166). They are **deliberately not** waived here — Phase 6 consolidates the duplicated pds3/pds4 logic into `_common.py`, so their sizes are about to change, and waiving them now would pre-empt that with a statement about to stop being true. Recorded as deferred observation 66, owned by Phase 6. Nothing is broken meanwhile: no gate enforces module length.

## Verification

`tests/api/` 26 passed, `ruff check src/pdsfile tests scripts` clean, `bash -n scripts/run-all-checks.sh` parses. No file under `src/` or `tests/` changed, so the full-data set is untouched by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QyABhcZoxQaRjUjRnguHPK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated modernization plans and decision records to clarify Ruff checking and formatting policies.
  * Documented permanent exclusions, module-size waivers, and deferred maintenance-tool cleanup.
  * Clarified the sequential workflow for upcoming modernization work.
  * Updated validation guidance to reflect that Ruff formatting is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->