### PR TITLE
ci: cancel a pull request's superseded run when a new commit lands

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,6 +11,19 @@ on:
   schedule:
     - cron: "00 08 * * *"   # 12am PST, 1am PDT
 
+# One run per pull request at a time: a new push cancels the run still going for
+# the previous commit. The data jobs need four of the five self-hosted runners at
+# once, so two live runs on one PR queue behind each other and only the newer one
+# is worth waiting for.
+#
+# Cancelling is limited to pull_request. The nightly schedule, pushes to main and
+# manual dispatches share the same runners but supersede nothing, so they group by
+# ref and are left to finish. The pull_request group keys on the PR number rather
+# than the ref so that it is stable if the branch is renamed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
The self-hosted pool is five runners and the `Test pdsfile` matrix claims four of them at once, so two live runs on one PR queue behind each other — and the older one is spending ~13 minutes of runner time on a commit nobody will look at again. That queueing is what made PR-triggered runs appear ~30 minutes after the push earlier today.

A `concurrency` group keyed on the PR number, with `cancel-in-progress`, ends the superseded run as soon as the newer commit arrives.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

Three deliberate choices:

**Cancelling is scoped to `pull_request`.** The nightly schedule, pushes to `main` and manual dispatches share the same runners but supersede nothing, so they group by ref and run to completion. `cancel-in-progress` takes an expression precisely so one workflow can do both.

**The group keys on the PR number, not the ref**, so it survives a branch rename and cannot be confused by two refs pointing at one PR.

**The `workflow_call` path is safe, and the reason is narrow enough to write down.** `run-tests.yml` is also called by `run-tests-and-opus.yml`, and inside a reusable workflow the `github` context resolves to the *caller* — so the callee would evaluate this group against the caller's workflow name and PR number. That caller fires only on pull requests to `main`, while this workflow's own `pull_request` trigger is scoped to `rewrite`, so the two never fire for the same PR and the group cannot collide with itself. A future workflow that calls this one for the same PR would need its own group; the comment in the file says so.

No job, step, matrix or trigger changes — the diff is the block above plus its comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated workflow run management.
  * Redundant pull-request runs are now canceled when a newer run starts, while scheduled, push, and manually triggered runs continue uninterrupted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->