### PR TITLE
refactor: one shared preamble for the three tool drivers

### DIFF
--- a/critiques/deferred-observations.md
+++ b/critiques/deferred-observations.md
@@ -3773,3 +3773,52 @@ and the `status = 0` stays behind — 14 lines move, not 15.
 not act.
 **Owner: recorded, not open — unless the owner wants the 15-line preamble
 extraction, which would be its own PR.**
+
+## From PR-28a (extract the drivers' shared preamble, Phase 6 follow-on)
+
+### Amended by the PR-28a executor (2026-08-07) — entry 130
+
+**The preamble extraction happened; the driver merge did not.** The owner took the
+last paragraph above and authorized it as its own PR. `_common.setup_run(spec, argv)`
+now holds the block and returns `(args, logger)`; each driver calls it and keeps its
+own `status = 0`, exactly as the paragraph predicted — 14 lines move, not 15.
+
+Two corrections to what that paragraph said, both measured rather than reasoned
+about:
+
+- The block is **25 lines** as it stands in each driver, 15 of them code. The
+  paragraph's "15-line preamble" counted the code lines; the contiguous block a
+  reader sees is 25.
+- The three copies differ on **two** lines, not one: `build_arg_parser` carries the
+  `_common.` qualifier as well as `resolve_log_root`. Both are the qualifier, so
+  the substance is unchanged.
+
+**What this PR deliberately did not do.** It did not touch the three loops, the
+seven forced variation points, the task headers, or `RunResult`. The measurement
+above stands: the drivers still do not collapse, and nothing here makes them closer
+to collapsing. **Owner: recorded, not open.**
+
+### Added by the PR-28a executor's own measurements (2026-08-07)
+
+149. **A traceback raised inside the preamble now names `setup_run`.** Extracting a
+     function adds a stack frame, and one input class reaches it: a `--log` root the
+     process cannot write into raises `PermissionError` from
+     `logger.add_handler(make_handler(path))`, the preamble's last line. On all ten
+     driver-backed tools the traceback gains three lines — the call site, its caret
+     row, and a `_common.py … in setup_run` frame — beneath the frame that still
+     names the driver. Nothing else moves: the 158-scenario tool-run capture
+     covering every tool, every task and the failure paths is byte-identical between
+     base and head. This is a change to what a tool prints, on an input no test and
+     no golden covers, so it is recorded rather than normalized away. Whether a
+     traceback's shape is part of the CLI contract at all is the owner's call.
+     **Owner: open.**
+
+150. **`--log` is still only half pinned.** Before this PR no test drove a
+     maintenance tool with `--log` at all, so the preamble's handler wiring was
+     pinned by nothing, in triplicate. `test_driver_setup.py` now pins it for
+     `pds4checksums`, whose spec declares two handler factories. Two things it does
+     not reach: a pds3 spec, which declares one factory, so the ordering of the
+     tuple is pinned only where there are two of them; and the `PDS_LOG_ROOT`
+     fallback arriving at a real tool — `resolve_log_root` itself is unit-tested in
+     `test_re_validate.py`, but no test sets the variable and runs a tool.
+     **Owner: open.**

--- a/critiques/deferred-observations.md
+++ b/critiques/deferred-observations.md
@@ -3816,8 +3816,9 @@ to collapsing. **Owner: recorded, not open.**
 150. **Two lines of the preamble are pinned by no test at all.** Before this PR no
      test drove a driver-backed tool with `--log`, so the handler wiring was pinned
      by nothing, in triplicate; `test_driver_setup.py` now pins it. What no test
-     reaches, measured by deleting each line and running the whole
-     `tests/holdings_maintenance` suite, which reports 337 passed either way:
+     reaches, measured at `356e055` by deleting each line from `setup_run` and
+     running `pytest tests/holdings_maintenance` against the full holdings, which
+     reports the same count green as the unmutated tree:
      `spec.pdsfile_cls.set_log_root(args.log)`, whose absence silently empties the
      duplicate log tree; and the `if not args.quiet:` guard — `--quiet` is passed to
      none of the ten driver-backed tools anywhere in the suite. Both are covered by

--- a/critiques/deferred-observations.md
+++ b/critiques/deferred-observations.md
@@ -3813,12 +3813,28 @@ to collapsing. **Owner: recorded, not open.**
      traceback's shape is part of the CLI contract at all is the owner's call.
      **Owner: open.**
 
-150. **`--log` is still only half pinned.** Before this PR no test drove a
-     maintenance tool with `--log` at all, so the preamble's handler wiring was
-     pinned by nothing, in triplicate. `test_driver_setup.py` now pins it for
-     `pds4checksums`, whose spec declares two handler factories. Two things it does
-     not reach: a pds3 spec, which declares one factory, so the ordering of the
-     tuple is pinned only where there are two of them; and the `PDS_LOG_ROOT`
-     fallback arriving at a real tool — `resolve_log_root` itself is unit-tested in
-     `test_re_validate.py`, but no test sets the variable and runs a tool.
-     **Owner: open.**
+150. **Two lines of the preamble are pinned by no test at all.** Before this PR no
+     test drove a driver-backed tool with `--log`, so the handler wiring was pinned
+     by nothing, in triplicate; `test_driver_setup.py` now pins it. What no test
+     reaches, measured by deleting each line and running the whole
+     `tests/holdings_maintenance` suite, which reports 337 passed either way:
+     `spec.pdsfile_cls.set_log_root(args.log)`, whose absence silently empties the
+     duplicate log tree; and the `if not args.quiet:` guard — `--quiet` is passed to
+     none of the ten driver-backed tools anywhere in the suite. Both are covered by
+     this PR's tool-run capture, which is not a thing the repository runs. Also
+     unreached by any test: the `PDS_LOG_ROOT` fallback arriving at a tool.
+     `resolve_log_root` itself is unit-tested, but no test sets the variable and
+     runs one. **Owner: open.**
+
+151. **Two more near-copies of the preamble exist, and neither is a `setup_run`
+     caller.** `re_validate.main` (`pds3/re_validate.py`) and
+     `pdsdependency.main` (`pds3/pdsdependency.py`) each open with the same shape —
+     build a parser, resolve the log root, build a `PdsLogger`, add the stdout
+     handler unless `--quiet`, add an error handler under `<log>/<progname>` — and
+     neither can call `setup_run` as it stands. `re_validate` builds its logger with
+     a `limits=` argument and has no task flag to refuse; `pdsdependency` interleaves
+     its own path validation between the two halves, re-inlines
+     `resolve_log_root`'s body rather than calling it, and carries a second
+     definition of `LOGROOT_ENV = 'PDS_LOG_ROOT'` beside `_common.py`'s. The
+     duplicate constant is the part that can drift silently. Out of scope here — this
+     PR extracted what was identical, not what is merely similar. **Owner: open.**

--- a/critiques/pr-28a-validation.md
+++ b/critiques/pr-28a-validation.md
@@ -41,7 +41,7 @@ later, not part of setup.
 | `src/pdsfile/holdings_maintenance/_common.py` | 372 | 397 |
 | `src/pdsfile/holdings_maintenance/_shelf_common.py` | 523 | 501 |
 | `src/pdsfile/holdings_maintenance/_indexshelf_common.py` | 620 | 598 |
-| `tests/holdings_maintenance/test_driver_setup.py` | — | 47 |
+| `tests/holdings_maintenance/test_driver_setup.py` | — | 52 |
 
 14 code lines move; the function costs a `def` line and a docstring, so the three
 source files net 19 lines shorter. Nothing else changed: no rename, no signature
@@ -62,9 +62,21 @@ inventory and log-file lines are recorded after its sequence.
 
 Normalized: temporary tree and repo paths, wall-clock times, log-file time tags,
 elapsed times, and traceback **line** numbers. Traceback **file** names and
-function names are compared verbatim, which is the point. `.tar.gz` files are
-compared as their member lists rather than their compressed size, because the
-archive carries a directory entry whose modification time is the run's own.
+function names are compared verbatim, which is the point.
+
+Two records are compared less than verbatim, both because two runs of the same tree
+differ there and neither difference is about the code:
+
+- `ARTIFACTS` compares a `.tar.gz` by its **member list**, not its compressed size.
+  The archive carries a directory entry whose modification time is the run's own,
+  so the size moves between runs — measured, 143,816 against 143,828.
+- `LOGFILES` compares a tool's log lines as a **set**, unioned over every log file
+  it wrote, because which file a line lands in and how many files there are both
+  depend on which second a run started. Measured on the control before the raw
+  total was added: the same 292 lines arrived as 10 files in one run and 11 in the
+  next. The **raw line total** is recorded beside the set, so the failure
+  `log_paths_for`'s docstring names — one run's log written twice — is still
+  visible, which a set alone cannot show.
 
 **Base versus base first**, two independent runs of the same tree:
 
@@ -75,17 +87,38 @@ base      vs head        :   0 differing lines of 6,893
 
 Byte-identical. Not "attributed" — identical.
 
-### 3.1 One input class where the extraction is visible, found deliberately
+**The capture can fail**, checked against a throwaway worktree at head. Changing the
+"Missing task" message to "No task" moves **20 gate lines**, ten tools × one line
+each way; making the preamble ignore `--quiet` moves **410**; attaching only the
+first of a spec's handler factories moves **4 probe lines**. All three mutations
+live inside `setup_run`, so a capture blind to them would be blind to the change
+this PR makes.
 
-Any extracted function adds a stack frame, so a traceback raised *inside* the
-preamble would name it. Nothing in the 158 scenarios raises there, so a separate
-**20-scenario probe** went looking: each tool run twice with `--log`, once at a
-writable root and once at a root the process cannot write into. The unwritable case
-raises `PermissionError` from `logger.add_handler(make_handler(path))` — the
-preamble's last line — on all ten tools.
+The third is four lines rather than five because `pds4indexshelf`'s root
+`ERRORS.log` survives it: `run_index_main` creates its per-target handlers in the
+tool's own log directory rather than the target's, so that file gets written
+whether or not the preamble made it.
 
-Base-versus-base control on the probe: 0 differing lines. Base versus head: **30
-added lines, none removed, none changed**, three per tool and one cause:
+### 3.1 The `--log` probe, and the one input class where the extraction is visible
+
+No scenario above passes `--log`, so the gate reaches the preamble's last four
+lines — the ones that build the root handlers — but sees nothing they produce. A
+separate **20-scenario probe** covers them: each tool run twice, once with a
+writable `--log` root and once with a root the process cannot write into, on a tree
+nothing has initialized so that the run logs an error and the handlers have
+something to write. Each writable run records the whole log root, every path and
+each file's line count, so a handler that was created and never attached — which
+leaves the same file behind — is told apart from one that was attached.
+
+Those `LOGROOT` records are identical between base and head. The probe's base
+versus base is 0 differing lines, and base versus head is **30 added lines, none
+removed, none changed** — three per tool, one cause, and all of it in the
+unwritable run.
+
+A traceback raised *inside* the preamble names the extracted function, because any
+extracted function adds a stack frame. Nothing in the 158 gate scenarios raises
+there; the unwritable `--log` root does, from
+`logger.add_handler(make_handler(path))`, on all ten tools:
 
 ```
    File "$REPO/.../_common.py", line <N>, in run_main
@@ -114,13 +147,21 @@ Full data, `PDSFILE_TEST_HOLDINGS=full`, both modes, per-id outcome diffed:
 The five `--mode s` failures are the same five ids at both trees; they are the
 tree's existing shelves-only failures, untouched here.
 
-The new test is the one addition §5 permits, and it closes a real gap: no test in
-the suite drove a maintenance tool with `--log`, so the preamble's handler wiring
-was pinned by nothing — in triplicate before this PR, and in one place after it. It
-uses `pds4checksums`, which declares two handler factories, and asserts both
-`WARNINGS.log` and `ERRORS.log` appear under the log root. **Negative control:**
-with `spec.handler_factories[:1]` substituted in `setup_run`, the test fails; the
-mutation was reverted before anything else was run.
+The new test is the one addition §5 permits, and it closes a real gap: no test drove
+a **driver-backed** tool with `--log`, so the preamble's handler wiring was pinned
+by nothing — in triplicate before this PR, and in one place after it.
+(`test_re_validate.py` does pass `--log`, to a tool with its own `main()` that
+reaches none of the three drivers.) The test uses `pds4checksums`, which declares
+two handler factories, and asserts that the tool's directory under the log root
+holds **exactly** `ERRORS.log` and `WARNINGS.log` and that **both have content**
+after a run that logs an error — creation and attachment are different properties,
+and each handler opens its file when it is created, so existence alone cannot tell
+them apart.
+
+**Negative controls, three mutations of `setup_run`,** each reverted before anything
+else was run: `handler_factories[:1]` fails the exact-list assertion; creating the
+handlers without `logger.add_handler` leaves both files empty and fails the content
+assertions; dropping the `if args.log:` branch leaves the directory absent.
 
 ## 5. Standing gates
 

--- a/critiques/pr-28a-validation.md
+++ b/critiques/pr-28a-validation.md
@@ -38,7 +38,7 @@ later, not part of setup.
 
 | file | base | head |
 |---|---:|---:|
-| `src/pdsfile/holdings_maintenance/_common.py` | 372 | 397 |
+| `src/pdsfile/holdings_maintenance/_common.py` | 372 | 398 |
 | `src/pdsfile/holdings_maintenance/_shelf_common.py` | 523 | 501 |
 | `src/pdsfile/holdings_maintenance/_indexshelf_common.py` | 620 | 598 |
 | `tests/holdings_maintenance/test_driver_setup.py` | — | 52 |
@@ -74,9 +74,14 @@ differ there and neither difference is about the code:
   it wrote, because which file a line lands in and how many files there are both
   depend on which second a run started. Measured on the control before the raw
   total was added: the same 292 lines arrived as 10 files in one run and 11 in the
-  next. The **raw line total** is recorded beside the set, so the failure
-  `log_paths_for`'s docstring names — one run's log written twice — is still
-  visible, which a set alone cannot show.
+  next. The **raw line total** is recorded beside the set as a second, cheaper
+  check. It is not load-bearing, and the record says so rather than claiming a
+  safety net it does not provide: removing `log_paths_for`'s `paths[0] == paths[1]`
+  dedup — the duplication its docstring exists to prevent — moves the raw total on
+  all ten tools, but it moves the **set** on all ten too, because each driver logs
+  one `Log file` line per path. The other shape of duplication is unreachable:
+  pdslogger deduplicates handlers by path, so adding a second `file_handler` for
+  the same log leaves the byte count unmoved.
 
 **Base versus base first**, two independent runs of the same tree:
 
@@ -87,28 +92,45 @@ base      vs head        :   0 differing lines of 6,893
 
 Byte-identical. Not "attributed" — identical.
 
-**The capture can fail**, checked against a throwaway worktree at head. Changing the
-"Missing task" message to "No task" moves **20 gate lines**, ten tools × one line
-each way; making the preamble ignore `--quiet` moves **410**; attaching only the
-first of a spec's handler factories moves **4 probe lines**. All three mutations
-live inside `setup_run`, so a capture blind to them would be blind to the change
-this PR makes.
+**The capture can fail**, checked against throwaway worktrees at head. Every
+mutation below is inside `setup_run`, so a capture blind to one would be blind to
+the change this PR makes:
 
-The third is four lines rather than five because `pds4indexshelf`'s root
-`ERRORS.log` survives it: `run_index_main` creates its per-target handlers in the
-tool's own log directory rather than the target's, so that file gets written
-whether or not the preamble made it.
+| mutation | moves |
+|---|---|
+| the "Missing task" message becomes "No task" | 20 gate lines |
+| the preamble ignores `--quiet` | 410 gate lines |
+| `--quiet` ignored only when `--log` is given | 0 gate, **191 probe** |
+| only the first of a spec's handler factories is attached | 4 probe lines |
+| the handlers are created and never attached | 131 probe lines |
+| `spec.pdsfile_cls.set_log_root(args.log)` deleted | 0 gate, 154 probe |
 
 ### 3.1 The `--log` probe, and the one input class where the extraction is visible
 
 No scenario above passes `--log`, so the gate reaches the preamble's last four
 lines — the ones that build the root handlers — but sees nothing they produce. A
-separate **20-scenario probe** covers them: each tool run twice, once with a
-writable `--log` root and once with a root the process cannot write into, on a tree
-nothing has initialized so that the run logs an error and the handlers have
-something to write. Each writable run records the whole log root, every path and
-each file's line count, so a handler that was created and never attached — which
-leaves the same file behind — is told apart from one that was attached.
+separate **30-scenario probe** covers them: each tool run three times, with a
+writable `--log` root, with `--quiet` **and** a writable root, and with a root the
+process cannot write into. The tree is not initialized first, so the run logs an
+error and the handlers have something to write, and each writable run records the
+whole log root — every path, and each file's line count.
+
+The `--quiet`-with-`--log` run is there because it is the one cell of the
+preamble's two log branches nothing else reaches: no gate scenario passes `--log`
+and no other probe scenario passes `--quiet`. Without it, a preamble that honoured
+`--quiet` only when no log root was given produced a byte-identical gate, a
+byte-identical probe and a green suite. With it, that mutation moves 191 probe
+lines.
+
+Recording the log root's contents is what tells a handler that was **attached**
+from one that was merely created, since each opens its file when it is created.
+That control fires on **7 of the 10 tools** — measured, not assumed. It does not
+fire on `pds4archives`, whose probe run succeeds and logs nothing at WARNING or
+above, so its handler files are empty either way; nor on the two index shelf tools,
+because `run_index_main` creates its per-target handlers in the tool's own log
+directory rather than the target's, so those files are written whether or not the
+preamble made them. Seven tools is enough for the control to be a control, and the
+three exceptions are named rather than left for a reader to discover.
 
 Those `LOGROOT` records are identical between base and head. The probe's base
 versus base is 0 differing lines, and base versus head is **30 added lines, none
@@ -153,7 +175,8 @@ by nothing — in triplicate before this PR, and in one place after it.
 (`test_re_validate.py` does pass `--log`, to a tool with its own `main()` that
 reaches none of the three drivers.) The test uses `pds4checksums`, which declares
 two handler factories, and asserts that the tool's directory under the log root
-holds **exactly** `ERRORS.log` and `WARNINGS.log` and that **both have content**
+holds, **at its top level**, exactly `ERRORS.log` and `WARNINGS.log`, and that
+**both have content**
 after a run that logs an error — creation and attachment are different properties,
 and each handler opens its file when it is created, so existence alone cannot tell
 them apart.

--- a/critiques/pr-28a-validation.md
+++ b/critiques/pr-28a-validation.md
@@ -1,0 +1,132 @@
+# PR-28a validation — the drivers' shared preamble
+
+Base `b8b9703`. Branch `pr-28a-driver-preamble`. Python 3.12.3. Every measured run
+set `PYTHONPATH=$PWD/src` and ran from the tree being measured:
+
+```
+$ PYTHONPATH=$PWD/src python -c "import pdsfile; print(pdsfile.__file__)"
+/seti/all_repos/rms-pdsfile-pr28a/base/src/pdsfile/__init__.py
+/seti/all_repos/rms-pdsfile-pr28a/work/src/pdsfile/__init__.py
+```
+
+## 1. The premise, verified before acting on it
+
+The three drivers open with the same block. Cut mechanically at `b8b9703` —
+`_common.py` 284-308, `_shelf_common.py` 423-447, `_indexshelf_common.py` 528-552,
+25 lines each — the shelf and index shelf copies are byte-identical to each other,
+and each differs from `run_main`'s copy on exactly two lines:
+
+```
+1c1
+<     parser = build_arg_parser(spec)
+---
+>     parser = _common.build_arg_parser(spec)
+13c13
+<     resolve_log_root(args)
+---
+>     _common.resolve_log_root(args)
+```
+
+Both are the module qualifier, present only because two of the three callers live
+outside `_common.py`. (Deferred entry 130 named one of the two; there are two.)
+
+## 2. What changed
+
+`_common.setup_run(spec, argv)` holds the block and returns `(args, logger)`. Each
+driver calls it and keeps its own `status = 0`, which is a local its own flow reads
+later, not part of setup.
+
+| file | base | head |
+|---|---:|---:|
+| `src/pdsfile/holdings_maintenance/_common.py` | 372 | 397 |
+| `src/pdsfile/holdings_maintenance/_shelf_common.py` | 523 | 501 |
+| `src/pdsfile/holdings_maintenance/_indexshelf_common.py` | 620 | 598 |
+| `tests/holdings_maintenance/test_driver_setup.py` | — | 47 |
+
+14 code lines move; the function costs a `def` line and a docstring, so the three
+source files net 19 lines shorter. Nothing else changed: no rename, no signature
+change, no driver merge. Deferred entry 130's seven forced variation points stand.
+
+## 3. The tool-run capture
+
+Ten tools reach the three drivers — `pdsarchives`, `pdslinkshelf`, `pds4archives`,
+`pds4linkshelf` (`run_main`); `pdschecksums`, `pdsinfoshelf`, `pds4checksums`,
+`pds4infoshelf` (`run_selection_main`); `pdsindexshelf`, `pds4indexshelf`
+(`run_index_main`). The eleventh console script, `pdsdependency`, reaches none of
+them. **158 scenarios**: for each tool `--help`, no arguments, a missing task, an
+unknown flag, a nonexistent path, a validate before any initialize, all five tasks,
+two task flags at once, `--quiet`, and an unreadable target; plus `--archives` on
+the four tools that take it and the `--infoshelf` chain on the two checksum tools.
+Each tool's holdings tree is rebuilt from the test subsets first, and its artifact
+inventory and log-file lines are recorded after its sequence.
+
+Normalized: temporary tree and repo paths, wall-clock times, log-file time tags,
+elapsed times, and traceback **line** numbers. Traceback **file** names and
+function names are compared verbatim, which is the point. `.tar.gz` files are
+compared as their member lists rather than their compressed size, because the
+archive carries a directory entry whose modification time is the run's own.
+
+**Base versus base first**, two independent runs of the same tree:
+
+```
+base run 1 vs base run 2 :   0 differing lines of 6,893
+base      vs head        :   0 differing lines of 6,893
+```
+
+Byte-identical. Not "attributed" — identical.
+
+### 3.1 One input class where the extraction is visible, found deliberately
+
+Any extracted function adds a stack frame, so a traceback raised *inside* the
+preamble would name it. Nothing in the 158 scenarios raises there, so a separate
+**20-scenario probe** went looking: each tool run twice with `--log`, once at a
+writable root and once at a root the process cannot write into. The unwritable case
+raises `PermissionError` from `logger.add_handler(make_handler(path))` — the
+preamble's last line — on all ten tools.
+
+Base-versus-base control on the probe: 0 differing lines. Base versus head: **30
+added lines, none removed, none changed**, three per tool and one cause:
+
+```
+   File "$REPO/.../_common.py", line <N>, in run_main
++    (args, logger) = setup_run(spec, argv)
++                     ^^^^^^^^^^^^^^^^^^^^^
++  File "$REPO/.../_common.py", line <N>, in setup_run
+     logger.add_handler(make_handler(path))
+```
+
+The frame naming the driver is still there and still names the driver; a
+`setup_run` frame appears beneath it. This is an observable change to what a tool
+prints, on an input class no test and no golden covers, and it is reported rather
+than normalized away. Deferred entry 149.
+
+## 4. Test id sets
+
+Full data, `PDSFILE_TEST_HOLDINGS=full`, both modes, per-id outcome diffed:
+
+| | base | head |
+|---|---|---|
+| `--mode ns` | 1,100 passed, 34 skipped (1,134 ids) | 1,101 passed, 34 skipped (1,135 ids) |
+| `--mode s` | 5 failed, 1,095 passed, 34 skipped (1,134 ids) | 5 failed, 1,096 passed, 34 skipped (1,135 ids) |
+
+**One id added, none removed, no outcome change:**
+`tests/holdings_maintenance/test_driver_setup.py::test_a_log_root_gets_every_handler_the_spec_declares`.
+The five `--mode s` failures are the same five ids at both trees; they are the
+tree's existing shelves-only failures, untouched here.
+
+The new test is the one addition §5 permits, and it closes a real gap: no test in
+the suite drove a maintenance tool with `--log`, so the preamble's handler wiring
+was pinned by nothing — in triplicate before this PR, and in one place after it. It
+uses `pds4checksums`, which declares two handler factories, and asserts both
+`WARNINGS.log` and `ERRORS.log` appear under the log root. **Negative control:**
+with `spec.handler_factories[:1]` substituted in `setup_run`, the test fails; the
+mutation was reverted before anything else was run.
+
+## 5. Standing gates
+
+- `ruff check .` clean; configured gate clean;
+  `ruff check --preview --select E111,E112,E113` clean.
+- Ratchet, `--config 'lint.per-file-ignores = {}'`: **66 entries, 180 slots, 2,249
+  findings** at base and at head — unmoved. `[project.scripts]`: **11** at both.
+- `tests/api`: 26 passed. The four frozen files are md5-identical to `b8b9703`.
+- `scripts/run-all-checks.sh -c -s` with no holdings env vars: pass.

--- a/critiques/pr-28a-validation.md
+++ b/critiques/pr-28a-validation.md
@@ -158,7 +158,14 @@ than normalized away. Deferred entry 149.
 
 ## 4. Test id sets
 
-Full data, `PDSFILE_TEST_HOLDINGS=full`, both modes, per-id outcome diffed:
+Full data, `PDSFILE_TEST_HOLDINGS=full`, both modes, per-id outcome diffed.
+
+**Both rows are the whole tree.** `scripts/automated_tests/pdsfile_main_test.sh:75`
+scopes its `--mode s` pass to `tests/pds3file/ tests/rules/pds3/`, which earlier PRs
+reported as 558 ids; this run applied `--mode s` to every directory instead, so the
+row below is a superset of that pass and its count is not comparable with theirs.
+The five failures are a consequence: they are tests outside the script's
+shelves-only scope, failing identically at both trees.
 
 | | base | head |
 |---|---|---|

--- a/critiques/pr-28a-validation.md
+++ b/critiques/pr-28a-validation.md
@@ -43,9 +43,10 @@ later, not part of setup.
 | `src/pdsfile/holdings_maintenance/_indexshelf_common.py` | 620 | 598 |
 | `tests/holdings_maintenance/test_driver_setup.py` | — | 52 |
 
-14 code lines move; the function costs a `def` line and a docstring, so the three
-source files net 19 lines shorter. Nothing else changed: no rename, no signature
-change, no driver merge. Deferred entry 130's seven forced variation points stand.
+14 of the block's 15 code lines move — `status = 0` is the one that stays — and the
+function costs a `def` line and a docstring, so the three source files net **18
+lines shorter**. Nothing else changed: no rename, no signature change, no driver
+merge. Deferred entry 130's seven forced variation points stand.
 
 ## 3. The tool-run capture
 

--- a/critiques/pr-28a/check_record_numbers.py
+++ b/critiques/pr-28a/check_record_numbers.py
@@ -77,6 +77,9 @@ def at_base(path):
 
 
 def check_line_counts():
+    """Check each file's base and head counts, and the net the record draws from them."""
+
+    delta = 0
     for path in COUNTED:
         head = len(pathlib.Path(path).read_text(encoding='utf-8').splitlines())
         expect(f'| {head} |', f'{path} head line count')
@@ -85,6 +88,10 @@ def check_line_counts():
         except subprocess.CalledProcessError:
             continue                    # the file did not exist at BASE
         expect(f'| {base} |', f'{path} base line count')
+        if path.startswith('src/'):
+            delta += head - base
+
+    expect(f'**{-delta}\nlines shorter**', 'the net change across the three sources')
 
 
 def check_the_block_was_identical():

--- a/critiques/pr-28a/check_record_numbers.py
+++ b/critiques/pr-28a/check_record_numbers.py
@@ -1,0 +1,153 @@
+"""Re-derive every tree-readable number in PR-28a's records and fail if one has moved.
+
+Record accuracy is a mechanical check, not a review round (owner, 2026-08-07). This
+re-derives the numbers in `critiques/pr-28a-validation.md`, in PR-28a's entries in
+`critiques/deferred-observations.md`, and in the plan's PR-28a entry, from the tree
+itself, and reports any that no longer reproduces.
+
+Needles are matched with all runs of whitespace collapsed to one space, so a number
+that happens to sit across a line break still matches.
+
+What it cannot check: numbers that come from running something rather than from
+reading the tree -- the suite id counts, the capture's scenario and line counts.
+Those carry their commands in the record. It does check that the one test id the
+record names exists.
+
+Run from the repository root with the tree's own interpreter, 3.11 or newer (this
+reads pyproject.toml through tomllib):
+
+    python critiques/pr-28a/check_record_numbers.py
+
+It prints one line per number that does not reproduce, and exits 1 if any does not.
+"""
+
+import pathlib
+import re
+import subprocess
+import sys
+
+import tomllib
+
+BASE = 'b8b9703'                # the commit this PR branched from
+
+RECORDS = ('critiques/pr-28a-validation.md',
+           'critiques/deferred-observations.md',
+           'plans/2026-07-25-modernization-plan.md')
+
+# The files whose base and head line counts the record's section 2 table carries.
+COUNTED = ('src/pdsfile/holdings_maintenance/_common.py',
+           'src/pdsfile/holdings_maintenance/_shelf_common.py',
+           'src/pdsfile/holdings_maintenance/_indexshelf_common.py',
+           'tests/holdings_maintenance/test_driver_setup.py')
+
+# The block as it stood in each driver at BASE: (file, first line, last line).
+BLOCKS = (('src/pdsfile/holdings_maintenance/_common.py', 284, 308),
+          ('src/pdsfile/holdings_maintenance/_shelf_common.py', 423, 447),
+          ('src/pdsfile/holdings_maintenance/_indexshelf_common.py', 528, 552))
+
+TEST_ID = ('tests/holdings_maintenance/test_driver_setup.py',
+           'test_a_log_root_gets_every_handler_the_spec_declares')
+
+failures = []
+
+
+def collapsed(path):
+    """Return a document's text with every run of whitespace collapsed to one space."""
+
+    return re.sub(r'\s+', ' ', pathlib.Path(path).read_text(encoding='utf-8'))
+
+
+DOCS = {path: collapsed(path) for path in RECORDS}
+
+
+def expect(needle, why):
+    """Record a failure unless the needle appears in at least one record."""
+
+    flat = re.sub(r'\s+', ' ', needle)
+    if not any(flat in text for text in DOCS.values()):
+        failures.append(f'{why}: no record says {needle!r}')
+
+
+def at_base(path):
+    """Return a file's text as of BASE."""
+
+    return subprocess.run(['git', 'show', f'{BASE}:{path}'],
+                          capture_output=True, text=True, check=True).stdout
+
+
+def check_line_counts():
+    for path in COUNTED:
+        head = len(pathlib.Path(path).read_text(encoding='utf-8').splitlines())
+        expect(f'| {head} |', f'{path} head line count')
+        try:
+            base = len(at_base(path).splitlines())
+        except subprocess.CalledProcessError:
+            continue                    # the file did not exist at BASE
+        expect(f'| {base} |', f'{path} base line count')
+
+
+def check_the_block_was_identical():
+    """The premise: the three blocks differ only in the _common. qualifier."""
+
+    cuts = []
+    for path, first, last in BLOCKS:
+        lines = at_base(path).splitlines()[first - 1:last]
+        cuts.append([line.replace('_common.', '') for line in lines])
+
+    if len({tuple(cut) for cut in cuts}) != 1:
+        failures.append('the three blocks at BASE are not identical once the '
+                        '_common. qualifier is removed')
+
+    if len(cuts[0]) != 25:
+        failures.append(f'the block is {len(cuts[0])} lines, not 25')
+    expect('**25 lines**', 'block length')
+
+    code = [line for line in cuts[0] if line.strip() and not line.strip().startswith('#')]
+    if len(code) != 15:
+        failures.append(f'the block holds {len(code)} code lines, not 15')
+    expect('15 of them code', 'block code-line count')
+
+
+def check_the_ratchet():
+    data = tomllib.loads(pathlib.Path('pyproject.toml').read_text(encoding='utf-8'))
+    ignores = data['tool']['ruff']['lint']['per-file-ignores']
+    expect(f'**{len(ignores)} entries', 'ratchet entry count')
+    expect(f'{sum(len(codes) for codes in ignores.values())} slots',
+           'ratchet code-slot count')
+    expect(f'**{len(data["project"]["scripts"])}** at both', '[project.scripts] count')
+
+
+def check_the_named_test_exists():
+    path, name = TEST_ID
+    if f'def {name}(' not in pathlib.Path(path).read_text(encoding='utf-8'):
+        failures.append(f'{path} defines no {name}')
+    expect(name, 'the named test id')
+
+
+def check_the_tool_counts():
+    """Ten tools reach the three drivers; eleven console scripts exist."""
+
+    data = tomllib.loads(pathlib.Path('pyproject.toml').read_text(encoding='utf-8'))
+    reached = 0
+    for target in data['project']['scripts'].values():
+        module = target.partition(':')[0].replace('.', '/')
+        text = pathlib.Path('src', module + '.py').read_text(encoding='utf-8')
+        if re.search(r'\b(run_main|run_selection_main|run_index_main)\(', text):
+            reached += 1
+
+    if reached != 10:
+        failures.append(f'{reached} console scripts reach a driver, not 10')
+    expect('**158 scenarios**', 'the capture scenario count')
+
+
+check_line_counts()
+check_the_block_was_identical()
+check_the_ratchet()
+check_the_named_test_exists()
+check_the_tool_counts()
+
+for failure in failures:
+    print(failure)
+
+print(f'{len(failures)} number(s) did not reproduce')
+sys.exit(1 if failures else 0)

--- a/critiques/pr-28a/check_record_numbers.py
+++ b/critiques/pr-28a/check_record_numbers.py
@@ -10,8 +10,9 @@ that happens to sit across a line break still matches.
 
 What it cannot check: numbers that come from running something rather than from
 reading the tree -- the suite id counts, the capture's scenario and line counts.
-Those carry their commands in the record. It does check that the one test id the
-record names exists.
+Those carry their commands in the record, and nothing here re-derives them, so a
+needle for one of them would only be this file asserting its own literal. It does
+check that the one test id the record names exists.
 
 Run from the repository root with the tree's own interpreter, 3.11 or newer (this
 reads pyproject.toml through tomllib):
@@ -125,7 +126,7 @@ def check_the_named_test_exists():
 
 
 def check_the_tool_counts():
-    """Ten tools reach the three drivers; eleven console scripts exist."""
+    """Ten of the console scripts reach one of the three drivers."""
 
     data = tomllib.loads(pathlib.Path('pyproject.toml').read_text(encoding='utf-8'))
     reached = 0
@@ -137,7 +138,7 @@ def check_the_tool_counts():
 
     if reached != 10:
         failures.append(f'{reached} console scripts reach a driver, not 10')
-    expect('**158 scenarios**', 'the capture scenario count')
+    expect('Ten tools reach the three drivers', 'the count of driver-backed tools')
 
 
 check_line_counts()

--- a/critiques/pr-28a/round-1.md
+++ b/critiques/pr-28a/round-1.md
@@ -1,0 +1,67 @@
+# PR-28a adversarial review — round 1
+
+Reviewed at `4672e58`. **Nothing Major.** The reviewer byte-diffed the extracted
+body against all three base blocks, read the three drivers end to end for
+`args`/`logger`/`parser`/`status` liveness, ran ruff (full, and F401/F811/F841),
+ran `tests/holdings_maintenance` at head, re-verified all four capture transcripts
+by md5, and ran five mutations against the new test. Every finding was about what
+the **evidence** covered, not about the extraction.
+
+## Findings and disposition
+
+**1. Minor — the test asserted existence, not attachment. Fixed.** A handler created
+and never attached leaves the same file behind; the reviewer built that mutation and
+the test passed. The test now runs against a tree nothing has initialized, so the run
+logs an error, and asserts both handler files have **content**. Three negative
+controls, each reverted:
+
+| mutation of `setup_run` | test |
+|---|---|
+| pristine | 1 passed |
+| `handler_factories[:1]` | 1 failed |
+| `make_handler(path)` without `logger.add_handler` | 1 failed |
+| the whole `if args.log:` branch dropped | 1 failed |
+
+**2. Minor — two preamble lines are pinned by no test, and entry 150 named neither.
+Fixed in the record.** Measured, not asserted: deleting
+`spec.pdsfile_cls.set_log_root(args.log)`, and neutering the `if not args.quiet:`
+guard, each leave `tests/holdings_maintenance` at **337 passed**, the same as
+pristine. Entry 150 now names both, says the capture is what covers them, and keeps
+the `PDS_LOG_ROOT`-through-a-tool gap.
+
+**3. Minor — the capture could not see the handler wiring at all. Fixed in the
+harness.** No gate scenario passes `--log` (`grep -c '^ARGV:.*--log'` → 0 of 158),
+and the probe recorded only stdout and stderr, so the equivalence case for the four
+lines that build the root handlers rested entirely on the new test. The probe now
+records the whole log root — every path, and each file's line count — and no longer
+initializes first, so the run logs an error and an unattached handler is
+distinguishable from an attached one. Base-versus-base is still 0. New mutation
+control: `handler_factories[:1]` now moves **4 probe lines**. It is four rather than
+five because `run_index_main` writes its per-target handlers into the tool's own log
+directory, so `pds4indexshelf`'s root `ERRORS.log` appears either way — recorded in
+the validation record.
+
+**4. Minor — `LOGFILES` folds every log file into one set, and §3 did not say so.
+Fixed both ways.** The set is necessary — the same 292 lines arrived as 10 files in
+one control run and 11 in the next — but it cannot see duplication, which is the
+failure `log_paths_for`'s docstring exists to prevent. The record now discloses the
+normalization with that measurement, and the record itself carries the **raw line
+total** beside the set, which is stable and does show duplication.
+
+**5. Nit — one `expect()` in the checker asserted its own literal. Fixed.** The
+`'**158 scenarios**'` needle could not fail on a wrong capture. It is replaced by a
+needle for a claim the checker does derive, and the docstring now says why a
+run-derived number must not get one.
+
+**6. Nit — the test hard-codes the two log file names.** Addressed by the fix to
+finding 1: the assertion is now an exact list, so a third factory added to the spec
+fails it rather than passing unnoticed. Reading the names from `SPEC` itself was
+rejected — it would import a `Pds4File`-touching module into the test process for no
+gain.
+
+**7. Nit — "no test drove a maintenance tool with `--log`" was false. Fixed.**
+`test_re_validate.py` does; `re_validate` reaches none of the three drivers. The
+record now says "driver-backed". The reviewer also found two more near-copies of the
+preamble, in `re_validate.main` and `pdsdependency.main`, the latter re-inlining
+`resolve_log_root`'s body and carrying a second `LOGROOT_ENV = 'PDS_LOG_ROOT'`. Out
+of scope; recorded as deferred entry 151.

--- a/critiques/pr-28a/round-1.md
+++ b/critiques/pr-28a/round-1.md
@@ -23,11 +23,11 @@ controls, each reverted:
 | the whole `if args.log:` branch dropped | 1 failed |
 
 **2. Minor — two preamble lines are pinned by no test, and entry 150 named neither.
-Fixed in the record.** Measured, not asserted: deleting
+Fixed in the record.** Measured at `356e055`, not asserted: deleting
 `spec.pdsfile_cls.set_log_root(args.log)`, and neutering the `if not args.quiet:`
-guard, each leave `tests/holdings_maintenance` at **337 passed**, the same as
-pristine. Entry 150 now names both, says the capture is what covers them, and keeps
-the `PDS_LOG_ROOT`-through-a-tool gap.
+guard, each leave `pytest tests/holdings_maintenance` against the full holdings at
+**337 passed**, the same as the unmutated tree. Entry 150 now names both, says the
+capture is what covers them, and keeps the `PDS_LOG_ROOT`-through-a-tool gap.
 
 **3. Minor — the capture could not see the handler wiring at all. Fixed in the
 harness.** No gate scenario passes `--log` (`grep -c '^ARGV:.*--log'` → 0 of 158),

--- a/critiques/pr-28a/round-2.md
+++ b/critiques/pr-28a/round-2.md
@@ -1,0 +1,54 @@
+# PR-28a adversarial review — round 2
+
+Reviewed at `356e055`, including round 1's own changes to the test and the capture
+harness. **Nothing Major.** The reviewer re-derived the extraction rather than
+taking round 1's word for it — the extracted body differs from the base block by one
+blank line and the `return` — and re-diffed the gate independently. Two Minors and
+three Nits, all acted on.
+
+## Findings and disposition
+
+**1. Minor — the record overclaimed the attachment control. Corrected, and the
+number measured.** §3.1 said each writable probe run logs an error "so that the
+handlers have something to write", making an unattached handler visible. Built the
+mutation and counted: the control fires on **7 of the 10 tools**, not ten.
+`pds4archives`'s probe run succeeds and logs nothing at WARNING or above, so its
+handler files are empty in both halves; the two index shelf tools recreate the same
+files from `run_index_main`'s per-target loop, which writes into the tool's own log
+directory. The record now names all three exceptions.
+
+**2. Minor — one valid input class was executed by nothing: `--quiet` with `--log`.
+Fixed in the harness.** No gate scenario passed `--log`; no probe scenario passed
+`--quiet`. The reviewer proved the cell unpinned by mutating `if not args.quiet:` to
+`if not args.quiet or args.log:`, which changes behaviour only when both flags are
+given: byte-identical gate, byte-identical probe, 337 passed. The probe now runs
+each tool a third time, `--quiet` with a writable log root. Base-versus-base is
+still 0, base-versus-head is still the same 30 traceback lines, and the mutation
+that used to be invisible now moves **191 probe lines**.
+
+**3. Nit — `setup_run`'s `Raises:` named one of the three statuses it produces.
+Fixed.** `parse_args` exits 0 for `--help` and 2 for a command line it cannot
+classify; 30 of the 158 gate scenarios take one of those. The base had no such
+section, so this PR introduced the omission. The docstring now names all three.
+
+**4. Nit — `raw=`'s stated justification was not demonstrated. Corrected.** The
+reviewer built the duplication `log_paths_for` guards against and found the **set**
+moves for all ten tools too, because each driver logs one `Log file` line per path;
+and that the other shape is unreachable, since pdslogger deduplicates handlers by
+path. The total is kept as a second cheap check, and the record now says that
+rather than claiming a safety net.
+
+**5. Nit — the plan still carried the sentence round 1 fixed in the validation
+record, and one assertion was described too strongly. Both fixed.** The plan now
+says "driver-backed"; the record says the tool's log directory holds exactly the two
+files **at its top level**, which is what `glob('*.log')` asserts.
+
+## What round 2 checked and found clean
+
+Round 1's test change fails under the no-attach mutation, and its exact-two-element
+list is stable — both handler factories default to `rotation='none'`, so no rotated
+third file, and every per-target log lands one directory down. `logroot()` is
+deterministic across six independent captures. No stranded comments, no dead
+`parser`, no newly unused imports. `run_selection_main`'s and `run_index_main`'s
+`Raises:` sections remain true. `check_record_numbers.py` is not pytest-collectable
+and each of its `expect()` calls is backed by a tree-derived assertion.

--- a/plans/2026-07-25-modernization-plan.md
+++ b/plans/2026-07-25-modernization-plan.md
@@ -744,7 +744,8 @@ and awaits only that merge. All five pds3/pds4 tool-pairs are on the shared core
 Two things the phase did **not** do, deliberately: `pdsdependency` stays a
 standalone pds3-only tool (it does not fit the five-task `ToolSpec` shape), and the
 three drivers stay three — PR-28 measured whether they collapse now that every
-family has migrated and found they do not (deferred entry 130).
+family has migrated and found they do not (deferred entry 130). What that
+measurement did point at, the preamble the three drivers shared, is PR-28a below.
 
 **What the phase leaves behind.** **Nine deferred observations** — counted by
 observation number, grouped into six rows below because four of them are one
@@ -1083,6 +1084,30 @@ touched by this PR. PR-25a is the one that modernizes it. Record:
   re-create one tool's task-header wording. Measured, not acted on. What the
   measurement does point at is extracting the 15-line preamble, which would be its
   own small PR.
+
+**PR-28a (S)** `refactor: one shared preamble for the three tool drivers`
+The small PR the entry above points at, authorized by the owner after Phase 6
+closed. `_common.run_main`, `_shelf_common.run_selection_main` and
+`_indexshelf_common.run_index_main` opened with the same 25-line block — verified
+identical at `b8b9703`, modulo the `_common.` qualifier on two lines. It becomes
+`_common.setup_run(spec, argv)`, returning `(args, logger)`; each driver keeps its
+own `status = 0`. **Not a driver merge**: the seven forced variation points deferred
+entry 130 measured are untouched. Record: `critiques/pr-28a-validation.md`.
+
+**As executed:**
+- **Byte-identical, not merely attributed.** A 158-scenario capture — every tool
+  that reaches each driver, every task, `--help`, a missing task, an unknown flag, a
+  nonexistent path, an unreadable target, two task flags at once — differs on **0
+  lines** between base and head, against a base-versus-base control that also
+  differs on 0.
+- **One input class where the new frame shows.** A `--log` root the process cannot
+  write into raises inside the preamble, and that traceback now names `setup_run`.
+  Found by a deliberate 20-scenario probe rather than by the gate, and recorded as
+  deferred entry 149 for the owner to rule on.
+- **One test added**, the only id that moves in either mode:
+  `test_driver_setup.py::test_a_log_root_gets_every_handler_the_spec_declares`. It
+  closes a gap the extraction exposed — no test drove a maintenance tool with
+  `--log`, so the handler wiring was pinned by nothing.
 
 ### Phase 7 — Docstrings and documentation
 

--- a/plans/2026-07-25-modernization-plan.md
+++ b/plans/2026-07-25-modernization-plan.md
@@ -1102,11 +1102,12 @@ entry 130 measured are untouched. Record: `critiques/pr-28a-validation.md`.
   differs on 0.
 - **One input class where the new frame shows.** A `--log` root the process cannot
   write into raises inside the preamble, and that traceback now names `setup_run`.
-  Found by a deliberate 20-scenario probe rather than by the gate, and recorded as
-  deferred entry 149 for the owner to rule on.
+  Found by a deliberate 30-scenario `--log` probe rather than by the gate, and
+  recorded as deferred entry 149 for the owner to rule on. The same probe is what
+  covers the root-handler wiring, which no gate scenario reaches.
 - **One test added**, the only id that moves in either mode:
   `test_driver_setup.py::test_a_log_root_gets_every_handler_the_spec_declares`. It
-  closes a gap the extraction exposed — no test drove a maintenance tool with
+  closes a gap the extraction exposed — no test drove a **driver-backed** tool with
   `--log`, so the handler wiring was pinned by nothing.
 
 ### Phase 7 — Docstrings and documentation

--- a/src/pdsfile/holdings_maintenance/_common.py
+++ b/src/pdsfile/holdings_maintenance/_common.py
@@ -254,7 +254,7 @@ def setup_run(spec, argv):
         for make_handler in spec.handler_factories:
             logger.add_handler(make_handler(path))
 
-    return args, logger
+    return (args, logger)
 
 
 def log_paths_for(pdsf, method, *args, **kwargs):

--- a/src/pdsfile/holdings_maintenance/_common.py
+++ b/src/pdsfile/holdings_maintenance/_common.py
@@ -210,6 +210,53 @@ def build_arg_parser(spec):
     return parser
 
 
+def setup_run(spec, argv):
+    """Turn a command line into parsed arguments and a logger ready to write.
+
+    Every driver begins here, so the log root, the console handler and the root
+    handlers are wired the same way whichever driver a tool reaches.
+
+    Args:
+        spec: The tool's ToolSpec.
+        argv: The full command line, sys.argv.
+
+    Returns:
+        tuple: The parsed command line, and the PdsLogger with the tool's log root
+        set and its root handlers attached. The exit status is not among them: it
+        belongs to the run the caller is about to make, not to this setup.
+
+    Raises:
+        SystemExit: With status 1 when the command line names no task, so a caller
+        that returns from here has one to run.
+    """
+
+    parser = build_arg_parser(spec)
+
+    # Parse and validate the command line
+    args = parser.parse_args(argv[1:])
+
+    if not args.task:
+        print(spec.progname + ' error: Missing task')
+        sys.exit(1)
+
+    # Define the logging directory
+    resolve_log_root(args)
+
+    # Initialize the logger
+    logger = pdslogger.PdsLogger(spec.logname)
+    spec.pdsfile_cls.set_log_root(args.log)
+
+    if not args.quiet:
+        logger.add_handler(pdslogger.stdout_handler)
+
+    if args.log:
+        path = os.path.join(args.log, spec.progname)
+        for make_handler in spec.handler_factories:
+            logger.add_handler(make_handler(path))
+
+    return args, logger
+
+
 def log_paths_for(pdsf, method, *args, **kwargs):
     """Return the paths one target's run writes its log to, in order.
 
@@ -281,31 +328,9 @@ def run_main(spec, tasks, argv):
             reached.
     """
 
-    parser = build_arg_parser(spec)
-
-    # Parse and validate the command line
-    args = parser.parse_args(argv[1:])
-
-    if not args.task:
-        print(spec.progname + ' error: Missing task')
-        sys.exit(1)
+    (args, logger) = setup_run(spec, argv)
 
     status = 0
-
-    # Define the logging directory
-    resolve_log_root(args)
-
-    # Initialize the logger
-    logger = pdslogger.PdsLogger(spec.logname)
-    spec.pdsfile_cls.set_log_root(args.log)
-
-    if not args.quiet:
-        logger.add_handler(pdslogger.stdout_handler)
-
-    if args.log:
-        path = os.path.join(args.log, spec.progname)
-        for make_handler in spec.handler_factories:
-            logger.add_handler(make_handler(path))
 
     # Generate a list of pdsfiles for the target directories
     pdsdirs = []

--- a/src/pdsfile/holdings_maintenance/_common.py
+++ b/src/pdsfile/holdings_maintenance/_common.py
@@ -227,7 +227,8 @@ def setup_run(spec, argv):
 
     Raises:
         SystemExit: With status 1 when the command line names no task, so a caller
-        that returns from here has one to run.
+        that returns from here has one to run; or from the parser, with status 0
+        for --help and 2 for a command line it cannot classify.
     """
 
     parser = build_arg_parser(spec)

--- a/src/pdsfile/holdings_maintenance/_indexshelf_common.py
+++ b/src/pdsfile/holdings_maintenance/_indexshelf_common.py
@@ -525,31 +525,9 @@ def run_index_main(spec, tasks, argv):
             reached.
     """
 
-    parser = _common.build_arg_parser(spec)
-
-    # Parse and validate the command line
-    args = parser.parse_args(argv[1:])
-
-    if not args.task:
-        print(spec.progname + ' error: Missing task')
-        sys.exit(1)
+    (args, logger) = _common.setup_run(spec, argv)
 
     status = 0
-
-    # Define the logging directory
-    _common.resolve_log_root(args)
-
-    # Initialize the logger
-    logger = pdslogger.PdsLogger(spec.logname)
-    spec.pdsfile_cls.set_log_root(args.log)
-
-    if not args.quiet:
-        logger.add_handler(pdslogger.stdout_handler)
-
-    if args.log:
-        path = os.path.join(args.log, spec.progname)
-        for make_handler in spec.handler_factories:
-            logger.add_handler(make_handler(path))
 
     # Generate a list of index tables before logging
     pdsfiles = index_targets(spec, getattr(args, spec.unit))

--- a/src/pdsfile/holdings_maintenance/_shelf_common.py
+++ b/src/pdsfile/holdings_maintenance/_shelf_common.py
@@ -420,31 +420,9 @@ def run_selection_main(spec, tasks, argv):
             paths. A task that raises is logged and re-raised.
     """
 
-    parser = _common.build_arg_parser(spec)
-
-    # Parse and validate the command line
-    args = parser.parse_args(argv[1:])
-
-    if not args.task:
-        print(spec.progname + ' error: Missing task')
-        sys.exit(1)
+    (args, logger) = _common.setup_run(spec, argv)
 
     status = 0
-
-    # Define the logging directory
-    _common.resolve_log_root(args)
-
-    # Initialize the logger
-    logger = pdslogger.PdsLogger(spec.logname)
-    spec.pdsfile_cls.set_log_root(args.log)
-
-    if not args.quiet:
-        logger.add_handler(pdslogger.stdout_handler)
-
-    if args.log:
-        path = os.path.join(args.log, spec.progname)
-        for make_handler in spec.handler_factories:
-            logger.add_handler(make_handler(path))
 
     # Prepare the list of paths, then the list of tuples (pdsfile, selection)
     abspaths = resolve_holdings_paths(spec, getattr(args, spec.unit),

--- a/tests/holdings_maintenance/test_driver_setup.py
+++ b/tests/holdings_maintenance/test_driver_setup.py
@@ -1,17 +1,16 @@
 ##########################################################################################
 # tests/holdings_maintenance/test_driver_setup.py
 #
-# Pins the root log handlers _common.setup_run attaches for a tool.
+# Pins the log handlers _common.setup_run attaches at a tool's log root.
 #
 # setup_run is the preamble all three drivers begin with: it parses the command
-# line, resolves the log root, and builds the logger. Everything else it does is
-# pinned elsewhere -- the missing-task exit by test_task_flags.py, the log-root
-# fallback by test_re_validate.py's resolve_log_root cases -- but no other test
-# drives a maintenance tool with --log, so the handlers a spec's
-# handler_factories create at the log root are reached only here.
+# line, resolves the log root, builds the logger, and attaches the handlers the
+# tool's spec declares. No other test drives a driver-backed tool with --log, so
+# that last step is reached only here -- and reached in both halves, because a
+# handler that is created and never attached leaves the same file behind.
 #
 # pds4checksums declares two factories, a warning handler and an error handler, so
-# a preamble that attached only the first would fail this. It also carries the pds3
+# a preamble that attached only the first fails this. It also carries the pds3
 # tool's progname, which is the subdirectory the handlers are created in.
 ##########################################################################################
 
@@ -33,15 +32,21 @@ PROGNAME = 'pdschecksums'
 def test_a_log_root_gets_every_handler_the_spec_declares(fresh_tree, tmp_path):
     """--log wires each of the tool's handler factories into the tool's own directory.
 
-    The files exist whether or not the run has anything to write to them: each
-    handler opens its file when it is created.
+    The run validates a bundle that has no checksum file yet, so it logs an error.
+    That is what gives the handlers something to write: their files exist either
+    way, since each opens its file when it is created, and only what the files hold
+    says whether the logger ever reached them.
     """
 
     log_root = tmp_path / 'logroot'
 
-    run = support.run_tool(fresh_tree, 'pds4checksums', '--initialize',
+    run = support.run_tool(fresh_tree, 'pds4checksums', '--validate',
                            '--log', log_root, fresh_tree.path(BUNDLE_DIR))
 
-    assert run.returncode == 0, run.describe()
-    assert (log_root / PROGNAME / 'WARNINGS.log').is_file(), run.describe()
-    assert (log_root / PROGNAME / 'ERRORS.log').is_file(), run.describe()
+    assert run.error_lines, run.describe()
+
+    written = log_root / PROGNAME
+    assert (sorted(path.name for path in written.glob('*.log'))
+            == ['ERRORS.log', 'WARNINGS.log']), run.describe()
+    assert written.joinpath('ERRORS.log').read_text(), run.describe()
+    assert written.joinpath('WARNINGS.log').read_text(), run.describe()

--- a/tests/holdings_maintenance/test_driver_setup.py
+++ b/tests/holdings_maintenance/test_driver_setup.py
@@ -1,0 +1,47 @@
+##########################################################################################
+# tests/holdings_maintenance/test_driver_setup.py
+#
+# Pins the root log handlers _common.setup_run attaches for a tool.
+#
+# setup_run is the preamble all three drivers begin with: it parses the command
+# line, resolves the log root, and builds the logger. Everything else it does is
+# pinned elsewhere -- the missing-task exit by test_task_flags.py, the log-root
+# fallback by test_re_validate.py's resolve_log_root cases -- but no other test
+# drives a maintenance tool with --log, so the handlers a spec's
+# handler_factories create at the log root are reached only here.
+#
+# pds4checksums declares two factories, a warning handler and an error handler, so
+# a preamble that attached only the first would fail this. It also carries the pds3
+# tool's progname, which is the subdirectory the handlers are created in.
+##########################################################################################
+
+import pytest
+
+from tests.holdings_maintenance import subsets, support
+
+pytestmark = pytest.mark.full_holdings
+
+SOURCE_FLAVOR = 'pds4'
+SOURCE_FINGERPRINTS = subsets.PDS4_BUNDLE_SOURCES
+SOURCE_PATHS = subsets.paths_of(subsets.PDS4_BUNDLE_SOURCES)
+SOURCE_MTIMES = subsets.PDS4_BUNDLE_MTIMES
+
+BUNDLE_DIR = f'bundles/{subsets.PDS4_BUNDLESET}/{subsets.PDS4_BUNDLE}'
+PROGNAME = 'pdschecksums'
+
+
+def test_a_log_root_gets_every_handler_the_spec_declares(fresh_tree, tmp_path):
+    """--log wires each of the tool's handler factories into the tool's own directory.
+
+    The files exist whether or not the run has anything to write to them: each
+    handler opens its file when it is created.
+    """
+
+    log_root = tmp_path / 'logroot'
+
+    run = support.run_tool(fresh_tree, 'pds4checksums', '--initialize',
+                           '--log', log_root, fresh_tree.path(BUNDLE_DIR))
+
+    assert run.returncode == 0, run.describe()
+    assert (log_root / PROGNAME / 'WARNINGS.log').is_file(), run.describe()
+    assert (log_root / PROGNAME / 'ERRORS.log').is_file(), run.describe()


### PR DESCRIPTION
The three maintenance-tool drivers — `_common.run_main`, `_shelf_common.run_selection_main` and `_indexshelf_common.run_index_main` — each opened with the same 25-line block: build the parser, parse the command line, refuse a run with no task, resolve the log root, build the logger, attach the root handlers. Cut mechanically at `b8b9703`, the three copies are identical apart from the `_common.` qualifier that two of them need on two lines.

This extracts that block as `_common.setup_run(spec, argv)`, returning `(args, logger)`. `status = 0` stays behind in each driver: it is a local that driver's own flow reads later, not part of setting up a run.

**Not a driver merge.** PR-28 measured whether the three drivers collapse and found seven forced variation points (deferred entry 130). Nothing here reopens that: the loops, the variation points and the two return contracts are untouched. The case for this change is drift, not line count — the block needs no flag of any kind, and until now a change to the log-root resolution, the handler wiring or the "Missing task" message had to be made in three places with nothing to catch two of three being updated.

## Behaviour

A **158-scenario tool-run capture** — every one of the ten console scripts that reaches a driver, every task, plus `--help`, no arguments, a missing task, an unknown flag, a nonexistent path, an unreadable target, two task flags at once and `--quiet`, with `--archives` and the `--infoshelf` chain where they apply — is **byte-identical between base and head**, modulo traceback line numbers. Zero differing lines, against a base-versus-base control that also differs on zero. A separate **30-scenario `--log` probe** covers the root-handler wiring, which no gate scenario reaches, and records the whole log root for each writable run.

One input class does change, and it was found by looking for it: a `--log` root the process cannot write into raises `PermissionError` inside the preamble, and that traceback now carries a `setup_run` frame beneath the frame that still names the driver. Three added lines per tool, nothing removed, nothing changed. Recorded as deferred entry 149 rather than normalized away; no test or golden covers that input.

Six mutations of `setup_run` were run against the capture to show it can fail, including two that the review rounds found it was blind to.

## Tests

One id added in each mode, none removed, no outcome change: `tests/holdings_maintenance/test_driver_setup.py::test_a_log_root_gets_every_handler_the_spec_declares`. It closes a gap the extraction exposed — no test drove a driver-backed tool with `--log`, so the handler wiring was pinned by nothing. It asserts that the tool's directory under the log root holds, at its top level, exactly `ERRORS.log` and `WARNINGS.log` and that both have content after a run that logs an error, because each handler opens its file when it is created and existence alone cannot tell an attached handler from a merely created one.

Ratchet unmoved at 66 entries / 180 slots / 2,249 findings; `[project.scripts]` still 11; `tests/api` 26 passed with the four frozen files byte-identical to `b8b9703`.

Record: `critiques/pr-28a-validation.md`, with the two review rounds under `critiques/pr-28a/`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized setup across maintenance tools, including command-line validation, logging, and log-directory configuration.
  * Preserved existing tool behavior while improving consistency for console and file logging.

* **Bug Fixes**
  * Improved logging behavior when validation runs with `--log`, including creation of error and warning logs.

* **Tests**
  * Added coverage for log-handler configuration and full-holdings validation scenarios.
  * Added automated checks for documentation, test coverage, tool counts, and record consistency.

* **Documentation**
  * Updated modernization plans, validation reports, and review records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->